### PR TITLE
chore: prep for 1.0.0 (README /codeboarding gate + rename to CodeBoarding Review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ jobs:
     if: >
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
       - uses: CodeBoarding/CodeBoarding-action@v1

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'CodeBoarding Architecture Diff (Mermaid)'
-description: 'Posts a PR comment with a Mermaid architecture diagram showing which components changed (green added / yellow modified / red deleted) — nodes and arrows.'
+name: 'CodeBoarding Review'
+description: 'Visual system-design review on pull requests: a Mermaid diagram of the architectural changes — added, modified, and deleted components and relations.'
 author: 'CodeBoarding'
 
 branding:


### PR DESCRIPTION
Two release-prep changes so 1.0.0 ships them:
- **README** — restore the `/codeboarding` comment-text gate in the example `if:` (was dropped in the restyle; avoids a runner per collaborator comment).
- **action.yml** — rename to **`CodeBoarding Review`** (the Marketplace name), aligned with the README title; refreshed description.