### PR TITLE
chore: shorten action description under Marketplace 125-char limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'CodeBoarding Action'
-description: 'Visual system-design review on pull requests: a Mermaid diagram of the architectural changes — added, modified, and deleted components and relations.'
+description: 'Visual system-design review on PRs: a Mermaid diagram of added, modified, and deleted components on every pull request.'
 author: 'CodeBoarding'
 
 branding:


### PR DESCRIPTION
The GitHub Marketplace listing rejects descriptions of 125+ characters. The current `action.yml` description is 149 chars. Trim to 119 while keeping the system-design-review framing, so the listing can be (re)published.