### PR TITLE
ci: run CodeBoarding action on this repo's own PRs

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -1,0 +1,41 @@
+name: CodeBoarding review
+
+on:
+  pull_request:
+    # Generate once, when the PR becomes reviewable, not on every push, so we
+    # don't spend an LLM job per commit. Add `synchronize` to re-run on each
+    # push, or refresh anytime with /codeboarding. 'closed' only cancels an
+    # in-flight review (see concurrency), it doesn't start one.
+    types: [opened, reopened, ready_for_review, closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: codeboarding-${{ github.event.pull_request.number || github.event.issue.number }}
+  # Cancel only when the PR closes — bot comments (issue_comment) and re-triggers
+  # must not cancel a running review; they queue behind it instead.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: >
+      (github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/codeboarding') &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    steps:
+      # Dogfood: run the action from the checked-out repo (uses: ./) so each PR
+      # exercises the action code under review, not the last published release.
+      # The action reads its scripts via github.action_path and checks the engine
+      # and target repo into subdirectories, so this local checkout is untouched.
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
Adds `.github/workflows/codeboarding.yml` so the action reviews its own pull requests (dogfooding).
Runs the local action via `checkout` + `uses: ./`, so each PR exercises the code under review; needs an `OPENROUTER_API_KEY` repo secret to post diagrams.