### PR TITLE
Add telemetry source attribution

### DIFF
--- a/scripts/cb_engine.py
+++ b/scripts/cb_engine.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 from pathlib import Path
 
@@ -142,6 +143,7 @@ def run_health(artifact_dir: str, repo: str, name: str) -> int:
 
 
 def main(argv=None) -> int:
+    os.environ.setdefault("CODEBOARDING_SOURCE", "github_action")
     p = argparse.ArgumentParser(description=__doc__)
     sub = p.add_subparsers(dest="cmd", required=True)
 

--- a/tests/test_cb_engine.py
+++ b/tests/test_cb_engine.py
@@ -1,6 +1,7 @@
 """Smoke tests for scripts/cb_engine.py — verify it calls the engine API correctly,
 using stub modules so no real engine venv is needed."""
 
+import os
 import sys
 import tempfile
 import types
@@ -8,6 +9,7 @@ import unittest
 from contextlib import redirect_stderr
 from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 import cb_engine  # noqa: E402
@@ -91,6 +93,21 @@ class TestAnalysis(_Base):
             "--source-sha", "abc123",
         ])
         self.assertEqual(rf.calls[0]["depth_level"], 2)
+
+    def test_main_sets_github_action_source(self):
+        rf = _Rec()
+        self._install(run_full=rf)
+        with patch.dict(os.environ, {}, clear=True):
+            cb_engine.main([
+                "base",
+                "--repo", "/repo",
+                "--out", "/out",
+                "--name", "myrepo",
+                "--run-id", "rid-base",
+                "--depth", "2",
+                "--source-sha", "abc123",
+            ])
+            self.assertEqual(os.environ["CODEBOARDING_SOURCE"], "github_action")
 
     def test_main_rejects_invalid_depth(self):
         for depth in ("0", "4", "x"):


### PR DESCRIPTION
Propagate an explicit CodeBoarding source across core, wrapper, VS Code, and the GitHub Action so telemetry can attribute user-facing entry points. The wrapper keeps source attribution per session and injects it into spawned core processes without relying on mutable global environment state.