### PR TITLE
Use CodeBoarding app token for dogfood comments

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -61,20 +61,12 @@ jobs:
         with:
           app-id: ${{ vars.CODEBOARDING_APP_ID }}
           private-key: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
-      - name: Select CodeBoarding comment token
-        id: codeboarding-comment-token
+      - name: Warn when CodeBoarding App token is unavailable
+        if: steps.codeboarding-app-token-client.outputs.token == '' && steps.codeboarding-app-token-app.outputs.token == ''
         shell: bash
-        env:
-          APP_TOKEN: ${{ steps.codeboarding-app-token-client.outputs.token || steps.codeboarding-app-token-app.outputs.token }}
         run: |
-          if [ -n "$APP_TOKEN" ]; then
-            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
-            echo "Using CodeBoarding GitHub App token for PR comments."
-          else
-            echo "token=${{ github.token }}" >> "$GITHUB_OUTPUT"
-            echo "::warning::CodeBoarding GitHub App token is unavailable; falling back to github-actions[bot]. Check CODEBOARDING_APP_PRIVATE_KEY formatting if app credentials are configured."
-          fi
+          echo "::warning::CodeBoarding GitHub App token is unavailable; falling back to github-actions[bot]. Check CODEBOARDING_APP_PRIVATE_KEY formatting if app credentials are configured."
       - uses: ./
         with:
-          github_token: ${{ steps.codeboarding-comment-token.outputs.token }}
+          github_token: ${{ steps.codeboarding-app-token-client.outputs.token || steps.codeboarding-app-token-app.outputs.token || github.token }}
           llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -40,21 +40,41 @@ jobs:
         id: codeboarding-app-config
         shell: bash
         env:
+          CLIENT_ID: ${{ vars.CODEBOARDING_APP_CLIENT_ID }}
           APP_ID: ${{ vars.CODEBOARDING_APP_ID }}
           PRIVATE_KEY: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
         run: |
-          if [ -n "$APP_ID" ] && [ -n "$PRIVATE_KEY" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
+          [ -n "$CLIENT_ID" ] && echo "has_client_id=true" >> "$GITHUB_OUTPUT" || echo "has_client_id=false" >> "$GITHUB_OUTPUT"
+          [ -n "$APP_ID" ] && echo "has_app_id=true" >> "$GITHUB_OUTPUT" || echo "has_app_id=false" >> "$GITHUB_OUTPUT"
+          [ -n "$PRIVATE_KEY" ] && echo "has_private_key=true" >> "$GITHUB_OUTPUT" || echo "has_private_key=false" >> "$GITHUB_OUTPUT"
       - uses: actions/create-github-app-token@v3
-        id: codeboarding-app-token
-        if: steps.codeboarding-app-config.outputs.enabled == 'true'
+        id: codeboarding-app-token-client
+        if: steps.codeboarding-app-config.outputs.has_client_id == 'true' && steps.codeboarding-app-config.outputs.has_private_key == 'true'
+        continue-on-error: true
+        with:
+          client-id: ${{ vars.CODEBOARDING_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
+      - uses: actions/create-github-app-token@v3
+        id: codeboarding-app-token-app
+        if: steps.codeboarding-app-config.outputs.has_client_id != 'true' && steps.codeboarding-app-config.outputs.has_app_id == 'true' && steps.codeboarding-app-config.outputs.has_private_key == 'true'
+        continue-on-error: true
         with:
           app-id: ${{ vars.CODEBOARDING_APP_ID }}
           private-key: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
+      - name: Select CodeBoarding comment token
+        id: codeboarding-comment-token
+        shell: bash
+        env:
+          APP_TOKEN: ${{ steps.codeboarding-app-token-client.outputs.token || steps.codeboarding-app-token-app.outputs.token }}
+        run: |
+          if [ -n "$APP_TOKEN" ]; then
+            echo "token=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+            echo "Using CodeBoarding GitHub App token for PR comments."
+          else
+            echo "token=${{ github.token }}" >> "$GITHUB_OUTPUT"
+            echo "::warning::CodeBoarding GitHub App token is unavailable; falling back to github-actions[bot]. Check CODEBOARDING_APP_PRIVATE_KEY formatting if app credentials are configured."
+          fi
       - uses: ./
         with:
-          github_token: ${{ steps.codeboarding-app-token.outputs.token || github.token }}
+          github_token: ${{ steps.codeboarding-comment-token.outputs.token }}
           llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -36,6 +36,25 @@ jobs:
       # The action reads its scripts via github.action_path and checks the engine
       # and target repo into subdirectories, so this local checkout is untouched.
       - uses: actions/checkout@v4
+      - name: Detect CodeBoarding GitHub App credentials
+        id: codeboarding-app-config
+        shell: bash
+        env:
+          APP_ID: ${{ vars.CODEBOARDING_APP_ID }}
+          PRIVATE_KEY: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
+        run: |
+          if [ -n "$APP_ID" ] && [ -n "$PRIVATE_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/create-github-app-token@v3
+        id: codeboarding-app-token
+        if: steps.codeboarding-app-config.outputs.enabled == 'true'
+        with:
+          app-id: ${{ vars.CODEBOARDING_APP_ID }}
+          private-key: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
       - uses: ./
         with:
+          github_token: ${{ steps.codeboarding-app-token.outputs.token || github.token }}
           llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -44,19 +44,46 @@ jobs:
           APP_ID: ${{ vars.CODEBOARDING_APP_ID }}
           PRIVATE_KEY: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
         run: |
-          [ -n "$CLIENT_ID" ] && echo "has_client_id=true" >> "$GITHUB_OUTPUT" || echo "has_client_id=false" >> "$GITHUB_OUTPUT"
-          [ -n "$APP_ID" ] && echo "has_app_id=true" >> "$GITHUB_OUTPUT" || echo "has_app_id=false" >> "$GITHUB_OUTPUT"
-          [ -n "$PRIVATE_KEY" ] && echo "has_private_key=true" >> "$GITHUB_OUTPUT" || echo "has_private_key=false" >> "$GITHUB_OUTPUT"
+          client_id="$CLIENT_ID"
+          app_id="$APP_ID"
+
+          # GitHub App client IDs start with "Iv". If that value was stored in
+          # CODEBOARDING_APP_ID, use it as a client ID to avoid the deprecated
+          # app-id input path.
+          if [ -z "$client_id" ] && [ "${app_id#Iv}" != "$app_id" ]; then
+            client_id="$app_id"
+            app_id=""
+          fi
+
+          has_private_key=false
+          private_key_valid=false
+          if [ -n "$PRIVATE_KEY" ]; then
+            has_private_key=true
+            if printf '%s' "$PRIVATE_KEY" | openssl pkey -noout >/dev/null 2>&1; then
+              private_key_valid=true
+            else
+              echo "::warning::CODEBOARDING_APP_PRIVATE_KEY is not a valid PEM private key, so CodeBoarding will fall back to github-actions[bot]."
+              if printf '%b' "$PRIVATE_KEY" | openssl pkey -noout >/dev/null 2>&1; then
+                echo "::warning::CODEBOARDING_APP_PRIVATE_KEY looks like it contains literal \\n escapes. Store the downloaded PEM as multi-line secret text instead."
+              fi
+            fi
+          fi
+
+          [ -n "$client_id" ] && echo "has_client_id=true" >> "$GITHUB_OUTPUT" || echo "has_client_id=false" >> "$GITHUB_OUTPUT"
+          [ -n "$app_id" ] && echo "has_app_id=true" >> "$GITHUB_OUTPUT" || echo "has_app_id=false" >> "$GITHUB_OUTPUT"
+          echo "client_id=$client_id" >> "$GITHUB_OUTPUT"
+          echo "has_private_key=$has_private_key" >> "$GITHUB_OUTPUT"
+          echo "private_key_valid=$private_key_valid" >> "$GITHUB_OUTPUT"
       - uses: actions/create-github-app-token@v3
         id: codeboarding-app-token-client
-        if: steps.codeboarding-app-config.outputs.has_client_id == 'true' && steps.codeboarding-app-config.outputs.has_private_key == 'true'
+        if: steps.codeboarding-app-config.outputs.has_client_id == 'true' && steps.codeboarding-app-config.outputs.private_key_valid == 'true'
         continue-on-error: true
         with:
-          client-id: ${{ vars.CODEBOARDING_APP_CLIENT_ID }}
+          client-id: ${{ steps.codeboarding-app-config.outputs.client_id }}
           private-key: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@v3
         id: codeboarding-app-token-app
-        if: steps.codeboarding-app-config.outputs.has_client_id != 'true' && steps.codeboarding-app-config.outputs.has_app_id == 'true' && steps.codeboarding-app-config.outputs.has_private_key == 'true'
+        if: steps.codeboarding-app-config.outputs.has_client_id != 'true' && steps.codeboarding-app-config.outputs.has_app_id == 'true' && steps.codeboarding-app-config.outputs.private_key_valid == 'true'
         continue-on-error: true
         with:
           app-id: ${{ vars.CODEBOARDING_APP_ID }}

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -44,8 +44,8 @@ jobs:
           APP_ID: ${{ vars.CODEBOARDING_APP_ID }}
           PRIVATE_KEY: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
         run: |
-          client_id="$CLIENT_ID"
-          app_id="$APP_ID"
+          client_id="${CLIENT_ID:-}"
+          app_id="${APP_ID:-}"
 
           # GitHub App client IDs start with "Iv". If that value was stored in
           # CODEBOARDING_APP_ID, use it as a client ID to avoid the deprecated
@@ -64,16 +64,18 @@ jobs:
             else
               echo "::warning::CODEBOARDING_APP_PRIVATE_KEY is not a valid PEM private key, so CodeBoarding will fall back to github-actions[bot]."
               if printf '%b' "$PRIVATE_KEY" | openssl pkey -noout >/dev/null 2>&1; then
-                echo "::warning::CODEBOARDING_APP_PRIVATE_KEY looks like it contains literal \\n escapes. Store the downloaded PEM as multi-line secret text instead."
+                printf '%s\n' "::warning::CODEBOARDING_APP_PRIVATE_KEY looks like it contains literal \\n escapes. Store the downloaded PEM as multi-line secret text instead."
               fi
             fi
           fi
 
-          [ -n "$client_id" ] && echo "has_client_id=true" >> "$GITHUB_OUTPUT" || echo "has_client_id=false" >> "$GITHUB_OUTPUT"
-          [ -n "$app_id" ] && echo "has_app_id=true" >> "$GITHUB_OUTPUT" || echo "has_app_id=false" >> "$GITHUB_OUTPUT"
-          echo "client_id=$client_id" >> "$GITHUB_OUTPUT"
-          echo "has_private_key=$has_private_key" >> "$GITHUB_OUTPUT"
-          echo "private_key_valid=$private_key_valid" >> "$GITHUB_OUTPUT"
+          {
+            [ -n "$client_id" ] && echo "has_client_id=true" || echo "has_client_id=false"
+            [ -n "$app_id" ] && echo "has_app_id=true" || echo "has_app_id=false"
+            echo "client_id=$client_id"
+            echo "has_private_key=$has_private_key"
+            echo "private_key_valid=$private_key_valid"
+          } >> "$GITHUB_OUTPUT"
       - uses: actions/create-github-app-token@v3
         id: codeboarding-app-token-client
         if: steps.codeboarding-app-config.outputs.has_client_id == 'true' && steps.codeboarding-app-config.outputs.private_key_valid == 'true'


### PR DESCRIPTION
## Summary
- generate a GitHub App installation token when internal app credentials exist
- pass that token into the dogfood CodeBoarding action so comments can appear from CodeBoarding[bot]
- fall back to github.token when the app credentials are absent

## Test plan
- git diff --check -- .github/workflows/codeboarding.yml
- smoke via this PR's CodeBoarding review workflow