### PR TITLE
fix: drop [skip ci] from bot commits so merges trigger sync; guard the loop without it

### DIFF
--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -12,10 +12,12 @@ name: CodeBoarding sync
 on:
   push:
     branches: [main]
-    # Don't re-trigger on the files this workflow itself commits. Deliberately
-    # NOT '.codeboarding/**': that would also swallow pushes that only edit the
-    # user-authored .codeboarding/.codeboardingignore, which changes analysis
-    # scope and should regenerate the baseline.
+    # Loop guard: don't re-trigger on the files this workflow itself commits.
+    # Deliberately NOT '.codeboarding/**': that would also swallow pushes that
+    # only edit the user-authored .codeboarding/.codeboardingignore, which
+    # changes analysis scope and should regenerate the baseline. The action also
+    # skips re-analyzing its own bot commit as a backstop; the bot commit uses no
+    # [skip ci] (that would leak through squash-merges and skip real merges).
     paths-ignore:
       - '.codeboarding/*.md'
       - '.codeboarding/analysis.json'

--- a/README.md
+++ b/README.md
@@ -170,9 +170,11 @@ name: CodeBoarding sync
 on:
   push:
     branches: [main]
-    # Don't re-trigger on the files this workflow itself commits. Listed
-    # explicitly (not '.codeboarding/**') so that editing your own
-    # .codeboarding/.codeboardingignore still regenerates the docs.
+    # Loop guard: don't re-trigger on the files this workflow itself commits.
+    # Listed explicitly (not '.codeboarding/**') so that editing your own
+    # .codeboarding/.codeboardingignore still regenerates the docs. (The action
+    # also skips re-analyzing its own bot commit as a backstop, and deliberately
+    # does NOT use [skip ci] — that would leak through squash-merges.)
     paths-ignore:
       - '.codeboarding/*.md'
       - '.codeboarding/analysis.json'
@@ -204,7 +206,7 @@ Behavior worth knowing:
 - The first run on a branch is a full analysis; subsequent runs reuse the committed baseline and run incrementally when they can (the `analysis_mode` output tells you which happened).
 - The commit is skipped when nothing meaningful changed (an empty diff, or only `generated_at`/timestamp fields). The push retries a few times with fetch+rebase and fails open, so a race with another push never fails your CI.
 - Tag pushes are skipped. `pull_request` events soft-skip in sync mode, so a mistakenly shared workflow can never push docs from a PR run.
-- The default `commit_message` ends in `[skip ci]`; keep the `paths-ignore` list above anyway, in case you customize the message or use a push token whose commits trigger workflows.
+- The bot commit carries **no `[skip ci]`** — on a squash-merge that marker leaks into the merge commit and would skip the very sync run (and release tooling, CI) the merge should trigger. The regen loop is instead prevented by the `paths-ignore` list above **and** by the action skipping re-analysis of its own bot commit, so a merge to `main` reliably triggers a fresh incremental sync.
 - `output_dir` is owned by the action: pre-existing top-level markdown files in it are deleted on every run (stale component pages must not linger). Don't point it at a directory with hand-written docs.
 
 ### How the two modes work together
@@ -251,7 +253,7 @@ Be aware that `contents: write` is repo-wide — GitHub does not scope it to a b
 | `output_format` | sync | `.md` | Output format. Only `.md` is supported. |
 | `target_branch` | sync | `${{ github.ref_name }}` | Branch the generated docs are pushed to. |
 | `write_architecture_md` | sync | `true` | Also write `docs/development/architecture.md`: all rendered pages concatenated, `overview.md` first. |
-| `commit_message` | sync | `chore(codeboarding): sync architecture baseline [skip ci]` | Commit message for the generated docs. |
+| `commit_message` | sync | `chore(codeboarding): sync architecture baseline` | Commit message for the generated docs. No `[skip ci]` (it would leak through squash-merges); the regen loop is guarded by `paths-ignore` + the action's own bot-commit check. |
 | `force_full` | sync | `false` | Ignore any committed baseline and run a full analysis from scratch. Use to rebuild a stale or corrupt baseline (e.g. from a `workflow_dispatch`). |
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -925,14 +925,18 @@ runs:
           echo "ready=true" >> "$GITHUB_OUTPUT"   # already committed at this SHA → webview can read it
           exit 0
         fi
-        # Same architecture, only volatile timestamps differ: don't commit. The
-        # bot commit carries no "[skip ci]" (it would leak through squash-merges
-        # and skip real merges' workflows), so a workflow that re-runs on every
-        # push (synchronize) would otherwise re-commit a new generated_at forever.
-        # ready=true: the analysis already committed at this SHA still serves the webview.
-        if git diff --cached --quiet -I '"generated_at"' -I '"timestamp"'; then
+        # Same architecture, only volatile metadata differs: don't commit. The
+        # ignored fields must cover EVERY per-run field, or the loop below stays
+        # open: generated_at and the health timestamp, AND commit_hash — which
+        # tracks the analyzed head SHA, so on a synchronize re-run (whose head IS
+        # our previous bot commit) it changes even when the architecture didn't.
+        # The bot commit carries no "[skip ci]" (it would leak through squash-
+        # merges and skip real merges' workflows), so without ignoring all three
+        # a synchronize-triggered re-run would re-commit a fresh SHA/timestamp
+        # forever. ready=true: the analysis already committed serves the webview.
+        if git diff --cached --quiet -I '"generated_at"' -I '"timestamp"' -I '"commit_hash"'; then
           git reset -q
-          echo "::notice::Head analysis differs only in timestamps; nothing to commit."
+          echo "::notice::Head analysis differs only in volatile metadata (timestamps/commit_hash); nothing to commit."
           echo "ready=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi

--- a/action.yml
+++ b/action.yml
@@ -91,9 +91,9 @@ inputs:
     required: false
     default: 'true'
   commit_message:
-    description: 'Sync mode: commit message for the generated docs.'
+    description: 'Sync mode: commit message for the generated docs. Deliberately carries no "[skip ci]" — the regen loop is prevented by the workflow''s paths-ignore plus the action''s own bot-commit guard, so the marker is unneeded and (via squash-merge) would skip the workflows real merges should run.'
     required: false
-    default: 'chore(codeboarding): sync architecture baseline [skip ci]'
+    default: 'chore(codeboarding): sync architecture baseline'
   force_full:
     description: 'Sync mode: ignore any committed baseline and run a full analysis from scratch. Use to rebuild a stale or corrupt baseline (the manual escape hatch that replaces the old refresh-baseline workflow).'
     required: false
@@ -161,6 +161,7 @@ runs:
         OUTPUT_FORMAT: ${{ inputs.output_format }}
         WRITE_ARCH: ${{ inputs.write_architecture_md }}
         DEPTH: ${{ inputs.depth_level }}
+        HEAD_AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
       run: |
         set -uo pipefail
         skip() { echo "::notice::$1 Skipping."; echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0; }
@@ -188,6 +189,15 @@ runs:
           esac
           if [ "$EVENT" = "push" ] && [ "$REF_TYPE" = "tag" ]; then
             skip "Sync mode runs on branch pushes, not tag pushes."
+          fi
+          # Regen-loop guard: never re-analyze our OWN baseline commit. Sync
+          # commits as codeboarding[bot]; if a push's head commit is ours, skip.
+          # This holds even if a consumer omits the workflow's paths-ignore (the
+          # primary guard), and replaces the old "[skip ci]" marker — which
+          # leaked into squash-merge commit messages and wrongly skipped the
+          # workflows real merges should run (sync itself, release tooling, CI).
+          if [ "$EVENT" = "push" ] && [ "$HEAD_AUTHOR_EMAIL" = "codeboarding[bot]@users.noreply.github.com" ]; then
+            skip "Push head commit is CodeBoarding's own baseline commit; not re-analyzing (loop guard)."
           fi
           case "$OUTPUT_FORMAT" in
             .md) ;;
@@ -915,10 +925,21 @@ runs:
           echo "ready=true" >> "$GITHUB_OUTPUT"   # already committed at this SHA → webview can read it
           exit 0
         fi
+        # Same architecture, only volatile timestamps differ: don't commit. The
+        # bot commit carries no "[skip ci]" (it would leak through squash-merges
+        # and skip real merges' workflows), so a workflow that re-runs on every
+        # push (synchronize) would otherwise re-commit a new generated_at forever.
+        # ready=true: the analysis already committed at this SHA still serves the webview.
+        if git diff --cached --quiet -I '"generated_at"' -I '"timestamp"'; then
+          git reset -q
+          echo "::notice::Head analysis differs only in timestamps; nothing to commit."
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
 
         git config user.name "codeboarding[bot]"
         git config user.email "codeboarding[bot]@users.noreply.github.com"
-        git commit -m "chore(codeboarding): update architecture analysis [skip ci]" >/dev/null
+        git commit -m "chore(codeboarding): update architecture analysis" >/dev/null
 
         # Push to the PR head branch. The checkout used persist-credentials:false, so
         # authenticate the push explicitly with the workflow token (same-repo only).


### PR DESCRIPTION
**Problem.** The review bot commits `chore(codeboarding): update architecture analysis [skip ci]` to the PR branch. On a **squash-merge**, GitHub folds that message into the merge commit, so `[skip ci]` lands on `main` and skips every push-triggered workflow the merge should run — the **sync** run that refreshes the baseline from the *merged* code, **release-please**, and CI. The result: the committed baseline is a stale PR-time snapshot, never the merged state, and releases silently stop (this is why release PRs halted after v1.3.0).

**Fix.** Drop `[skip ci]` from both bot commit messages (review head-analysis and sync baseline) and replace its loop-prevention role with mechanisms that don't leak through a squash:
- the sync workflow's `paths-ignore` (already present) — the primary loop guard;
- a new action-side guard — sync skips a push whose **head commit is authored by `codeboarding[bot]`**, so it never re-analyzes its own baseline commit even if a consumer omits `paths-ignore`;
- the review commit now also skips on a **timestamp-only diff** (matching sync), so a `synchronize`-triggered re-run can't re-commit a fresh `generated_at` in a loop.

So a merge to `main` reliably triggers a fresh **incremental** sync (answering "how do we get the latest analysis on merge"), and the regen loop stays closed without `[skip ci]`.

**Testing:** Simulated the loop-guard shell across bot/non-bot/empty authors (bot → skip, others → analyze); actionlint + YAML clean; full unit suite (123) green. No `[skip ci]` remains in any commit message (only in explanatory comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)