### PR TITLE
feat: auto-detect depth_level from committed baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,10 @@ node_modules/
 __pycache__/
 *.py[cod]
 
-# CodeBoarding generated cache/log artifacts
-.codeboarding/logs/
-.codeboarding/health/*
-!.codeboarding/health/
-!.codeboarding/health/health_report.json
+# CodeBoarding generated artifacts are managed by sync mode.
+# Keep them ignored for humans; the action force-adds the files it owns.
+.codeboarding/
+docs/development/architecture.md
 
 # Environment files
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ __pycache__/
 *.py[cod]
 
 # CodeBoarding generated cache/log artifacts
-.codeboarding/static_analysis.pkl
-.codeboarding/static_analysis.sha
 .codeboarding/logs/
 .codeboarding/health/*
 !.codeboarding/health/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 One action, two modes: architecture review on every pull request, and a versioned, always-current architecture baseline on your main branch.
 
-- **`mode: review`** (the default) — CodeBoarding analyzes your architecture before and after a change, comments on the PR with an inline Mermaid diagram and hosted webview link, and uploads the PR-specific analysis JSON/health outputs as a GitHub Actions artifact. It never commits generated files to the PR branch. Runs on `pull_request` and `issue_comment`.
+- **`mode: review`** (the default) — CodeBoarding analyzes your architecture before and after a change, comments on the PR with an inline Mermaid diagram and hosted webview link, and uploads the PR-head `analysis.json` plus base-commit metadata as a GitHub Actions artifact. It never commits generated files to the PR branch. Runs on `pull_request` and `issue_comment`.
 - **`mode: sync`** — CodeBoarding keeps your architecture analysis versioned and current on your branch: on every push it commits the `analysis.json` baseline, `static_analysis.pkl` cache pair, health report, and readable markdown (`.codeboarding/*.md`), so reviews diff against your current architecture and your architecture has real git history. Runs on `push`, `workflow_dispatch`, and `schedule`. See [sync mode](#keep-your-architecture-versioned-sync-mode).
 
 Both modes run the [CodeBoarding](https://github.com/CodeBoarding/CodeBoarding) engine in CI: static analysis combined with LLM reasoning. They are designed to be used together — [sync mode keeps the baseline fresh that review mode diffs against](#how-the-two-modes-work-together) — but each works on its own.
@@ -23,7 +23,7 @@ Both modes run the [CodeBoarding](https://github.com/CodeBoarding/CodeBoarding) 
 - Builds or reuses a baseline architecture analysis for the PR base.
 - Runs incremental analysis on the PR head, then diffs components and relationships.
 - Posts a sticky PR comment with an inline Mermaid map. Green is added, yellow is modified, red (dashed) is deleted, for both nodes and edges.
-- Uploads the PR analysis outputs as a GitHub Actions artifact and links the hosted webview to that artifact instead of committing generated files to the PR branch.
+- Uploads the PR-head `analysis.json` plus base-commit metadata as a GitHub Actions artifact and links the hosted webview to that artifact instead of committing generated files to the PR branch.
 
 A PR comment looks like this:
 
@@ -287,7 +287,7 @@ Review mode does not need `contents: write`: PR-specific generated files are sto
 | `diagram_md` | review | Path to the generated Mermaid markdown block on the runner. |
 | `n_changed` | review | Number of changed components, counted recursively. |
 | `truncated` | review | `true` when the graph was reduced to fit GitHub Mermaid limits. |
-| `review_artifact_url` | review | GitHub Actions artifact URL containing the PR base/head analysis outputs. |
+| `review_artifact_url` | review | GitHub Actions artifact URL containing the PR-head `analysis.json` and base-commit metadata. |
 | `analysis_mode` | sync | `full` or `incremental`: whether the run rebuilt the analysis from scratch or reused the committed baseline. |
 | `files_written` | sync | The generated files written for the docs commit. |
 | `committed` | sync | `true` when a docs commit was pushed to `target_branch`; `false` when sync mode ran but had nothing to commit (or the push failed open). Empty only if sync mode did not run. |

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 One action, two modes: architecture review on every pull request, and a versioned, always-current architecture baseline on your main branch.
 
-- **`mode: review`** (the default) — CodeBoarding analyzes your architecture before and after a change, then comments on the PR with an inline Mermaid diagram of what changed: added, modified, and deleted components and the relationships between them. Runs on `pull_request` and `issue_comment`.
-- **`mode: sync`** — CodeBoarding keeps your architecture analysis versioned and current on your branch: on every push it commits the `analysis.json` baseline plus readable markdown (`.codeboarding/*.md`), so reviews diff against your current architecture and your architecture has real git history. Runs on `push`, `workflow_dispatch`, and `schedule`. See [sync mode](#keep-your-architecture-versioned-sync-mode).
+- **`mode: review`** (the default) — CodeBoarding analyzes your architecture before and after a change, comments on the PR with an inline Mermaid diagram and hosted webview link, and uploads the PR-specific analysis JSON/health outputs as a GitHub Actions artifact. It never commits generated files to the PR branch. Runs on `pull_request` and `issue_comment`.
+- **`mode: sync`** — CodeBoarding keeps your architecture analysis versioned and current on your branch: on every push it commits the `analysis.json` baseline, `static_analysis.pkl` cache pair, health report, and readable markdown (`.codeboarding/*.md`), so reviews diff against your current architecture and your architecture has real git history. Runs on `push`, `workflow_dispatch`, and `schedule`. See [sync mode](#keep-your-architecture-versioned-sync-mode).
 
 Both modes run the [CodeBoarding](https://github.com/CodeBoarding/CodeBoarding) engine in CI: static analysis combined with LLM reasoning. They are designed to be used together — [sync mode keeps the baseline fresh that review mode diffs against](#how-the-two-modes-work-together) — but each works on its own.
 
@@ -23,6 +23,7 @@ Both modes run the [CodeBoarding](https://github.com/CodeBoarding/CodeBoarding) 
 - Builds or reuses a baseline architecture analysis for the PR base.
 - Runs incremental analysis on the PR head, then diffs components and relationships.
 - Posts a sticky PR comment with an inline Mermaid map. Green is added, yellow is modified, red (dashed) is deleted, for both nodes and edges.
+- Uploads the PR analysis outputs as a GitHub Actions artifact and links the hosted webview to that artifact instead of committing generated files to the PR branch.
 
 A PR comment looks like this:
 
@@ -72,9 +73,7 @@ on:
     types: [created]
 
 permissions:
-  # write lets the action commit analysis.json to the PR branch so the comment can
-  # link to the webview diff. Drop to `read` to keep the comment without that link.
-  contents: write
+  contents: read
   pull-requests: write
   issues: write
   # Lets the action mint a short-lived GitHub OIDC token so the free hosted tier
@@ -177,7 +176,9 @@ In review workflows that include `issue_comment`, anyone whose comment reaches t
 With `mode: sync`, the action analyzes the pushed commit and commits the results back to the branch (as `codeboarding[bot]`), so your architecture analysis stays versioned in git and tracks the code instead of drifting from it:
 
 - `.codeboarding/*.md` — rendered architecture docs: `overview.md` plus one page per component (directory configurable via `output_dir`).
-- `.codeboarding/analysis.json` — the machine-readable analysis, which doubles as the baseline that review mode and the webview diff against (alongside `codeboarding_version.json` and `health/health_report.json`).
+- `.codeboarding/analysis.json` — the machine-readable analysis, which doubles as the baseline that review mode diffs against.
+- `.codeboarding/static_analysis.pkl` + `.codeboarding/static_analysis.sha` — the static-analysis cache pair used to keep future incremental runs fast and reproducible.
+- `.codeboarding/health/health_report.json` — health findings for the committed baseline.
 - `docs/development/architecture.md` (optional, on by default) — all pages concatenated into a single document, `overview.md` first. Disable with `write_architecture_md: false`.
 
 Create `.github/workflows/codeboarding-sync.yml` next to your review workflow:
@@ -196,6 +197,8 @@ on:
     paths-ignore:
       - '.codeboarding/*.md'
       - '.codeboarding/analysis.json'
+      - '.codeboarding/static_analysis.pkl'
+      - '.codeboarding/static_analysis.sha'
       - '.codeboarding/codeboarding_version.json'
       - '.codeboarding/health/**'
       - 'docs/development/architecture.md'
@@ -223,7 +226,7 @@ jobs:
 
 Behavior worth knowing:
 
-- The first run on a branch is a full analysis; subsequent runs reuse the committed baseline and run incrementally when they can (the `analysis_mode` output tells you which happened).
+- The first run on a branch is a full analysis at depth 2 by default; subsequent runs reuse the committed baseline and run incrementally when they can (the `analysis_mode` output tells you which happened). Once an `analysis.json` exists, its recorded `metadata.depth_level` is preserved for incremental runs and fallback-full recovery.
 - The commit is skipped when nothing meaningful changed (an empty diff, or only `generated_at`/timestamp fields). The push retries a few times with fetch+rebase and fails open, so a race with another push never fails your CI.
 - Tag pushes are skipped. `pull_request` events soft-skip in sync mode, so a mistakenly shared workflow can never push docs from a PR run.
 - The bot commit carries **no `[skip ci]`** — on a squash-merge that marker leaks into the merge commit and would skip the very sync run (and release tooling, CI) the merge should trigger. The regen loop is instead prevented by the `paths-ignore` list above **and** by the action skipping re-analysis of its own bot commit, so a merge to `main` reliably triggers a fresh incremental sync.
@@ -233,20 +236,20 @@ Behavior worth knowing:
 
 Sync mode keeps the committed `.codeboarding/analysis.json` baseline fresh on main. Review mode reuses that committed baseline for the PR base, so PR reviews diff against your *current* main architecture and run incrementally instead of rebuilding a base from scratch — faster and cheaper per PR.
 
-Use the **same `depth_level` in both workflows** (both default to `2`). Review mode regenerates its base when the committed baseline is *deeper* than the workflow's `depth_level`, so a lowered depth silently forfeits the reuse. (A baseline recording a *shallower* depth is accepted: the engine records the depth actually reached, which can be less than requested on repos where no component expands.) Want cheaper, faster runs? Set `depth_level: 1` in *both* workflows.
+Leave `depth_level` empty unless you are choosing the depth for a first run or an intentional `force_full` rebuild. After a baseline exists, the committed `analysis.json` records the depth the engine should continue using, so review and sync mode do not need duplicate depth-selection logic.
 
-One caveat for squash-merge repos: the `analysis.json` that review mode commits to PR branches carries the PR-head SHA, which a squash merge orphans — so that copy can't validate as a baseline on main. Sync mode running on main is what keeps the baseline valid there.
+Review mode never commits generated artifacts to PR branches, so squash merges do not orphan PR-head `analysis.json` files on main. Sync mode running on main is the only writer of the committed baseline.
 
 ### Security: keep the two modes in separate workflows
 
 Use two thin workflow files, each with least privilege, exactly as in the snippets above:
 
-- **review workflow** — `on: pull_request` (types `[opened, reopened, ready_for_review]`; the quick start adds `closed` purely to cancel in-flight runs) + `issue_comment` (types `[created]`); `permissions: pull-requests: write, issues: write, contents: write` (`contents` only needed for `commit_head_analysis`/the webview link).
+- **review workflow** — `on: pull_request` (types `[opened, reopened, ready_for_review]`; the quick start adds `closed` purely to cancel in-flight runs) + `issue_comment` (types `[created]`); `permissions: contents: read, pull-requests: write, issues: write`.
 - **sync workflow** — `on: push` (branches `[main]`, with the `paths-ignore` list) + `workflow_dispatch`; `permissions: contents: write`.
 
 The anti-pattern to avoid: one workflow with `on: [push, pull_request]` and a single union permissions block — it forces every privilege either mode needs onto every trigger. Sync mode soft-skips on `pull_request` events as a backstop, but don't rely on it: keep the triggers and permissions split so each workflow grants only what its own mode uses.
 
-Be aware that `contents: write` is repo-wide — GitHub does not scope it to a branch — so the review workflow's webview push permission is itself a write-to-main-capable grant. If that doesn't sit well with your threat model, drop the review workflow to `contents: read` (you lose only the webview link, not the PR comment).
+Review mode does not need `contents: write`: PR-specific generated files are stored as workflow artifacts. Only sync mode pushes generated architecture state back to git.
 
 ## Inputs
 
@@ -258,9 +261,9 @@ Be aware that `contents: write` is repo-wide — GitHub does not scope it to a b
 | `proxy_url` | both | CodeBoarding proxy | Hosted LLM proxy base URL for the free/license tiers (the engine's `OPENROUTER_BASE_URL`). Override only for a self-hosted/dev proxy. |
 | `mode` | both | `review` | `review` posts the PR architecture-diff comment; `sync` analyzes on push and commits the architecture (`analysis.json` + rendered docs) to `target_branch`, keeping it versioned and current. |
 | `github_token` | both | `${{ github.token }}` | Token for GitHub API calls; in review mode it posts or updates the PR comment. |
-| `push_token` | both | `${{ github.token }}` | Token used for pushes: in review mode the generated `analysis.json` to the PR branch (for the webview link), in sync mode the architecture to `target_branch`. The workflow token can push when the workflow grants `permissions: contents: write`. Separate from `github_token` so commenting can use a GitHub App token while the push uses the workflow token. |
+| `push_token` | sync | `${{ github.token }}` | Token used for sync-mode pushes to `target_branch`. The workflow token can push when the workflow grants `permissions: contents: write`. Separate from `github_token` so commenting can use a GitHub App token while the push uses the workflow token. |
 | `engine_ref` | both | `v0.12.1` | CodeBoarding engine ref. Pin for reproducibility. |
-| `depth_level` | both | `2` | Analysis depth, 1 to 3. Higher is slower, costlier, and richer; drop to `1` for cheaper runs. Use the same value in your review and sync workflows ([why](#how-the-two-modes-work-together)). |
+| `depth_level` | both | empty (`2` for cold starts) | Analysis depth, 1 to 3, used for first analysis and `force_full` rebuilds. Once `.codeboarding/analysis.json` exists, its `metadata.depth_level` is the source of truth for incremental analysis and fallback-full recovery. |
 | `render_depth` | review | `1` | Display depth for the PR diagram. Keep `1` for a clean top-level view. |
 | `diagram_direction` | review | `LR` | Mermaid direction: `LR`, `TD`, `TB`, `RL`, or `BT`. |
 | `changed_only` | review | `false` | Render only changed components and incident edges. |
@@ -269,8 +272,7 @@ Be aware that `contents: write` is repo-wide — GitHub does not scope it to a b
 | `comment_header` | review | `Architecture review` | Heading for the PR comment. |
 | `trigger_command` | review | `/codeboarding` | Slash command for trusted on-demand runs. |
 | `cta_base_url` | review | empty | Click-proxy base URL: deep-links the editor link into VS Code/Cursor and adds a "get the extension" link (tracks owner/repo/pr). Empty links to the extension listing instead (GitHub strips `vscode:`/`cursor:` from comments). |
-| `webview_base_url` | review | `https://app.codeboarding.org` | Hosted webview base URL. The PR comment adds an "explore in browser" link to this PR's head-vs-base diff. Needs `commit_head_analysis` (same-repo PRs only); omitted on forks. Set empty to disable. |
-| `commit_head_analysis` | review | `true` | Commit the generated head `.codeboarding/analysis.json` (+ health report) to the PR branch so the webview can read it at the head SHA. Same-repo PRs only (the token is read-only on forks). |
+| `webview_base_url` | review | `https://app.codeboarding.org` | Hosted webview base URL. The PR comment links to an artifact-backed head-vs-base architecture diff. Set empty to disable the browser link. |
 | `output_dir` | sync | `.codeboarding` | Directory the rendered docs and analysis metadata are committed to. Owned by the action: pre-existing top-level `.md` files in it are deleted on every run. |
 | `output_format` | sync | `.md` | Output format. Only `.md` is supported. |
 | `target_branch` | sync | `${{ github.ref_name }}` | Branch the generated docs are pushed to. |
@@ -285,6 +287,7 @@ Be aware that `contents: write` is repo-wide — GitHub does not scope it to a b
 | `diagram_md` | review | Path to the generated Mermaid markdown block on the runner. |
 | `n_changed` | review | Number of changed components, counted recursively. |
 | `truncated` | review | `true` when the graph was reduced to fit GitHub Mermaid limits. |
+| `review_artifact_url` | review | GitHub Actions artifact URL containing the PR base/head analysis outputs. |
 | `analysis_mode` | sync | `full` or `incremental`: whether the run rebuilt the analysis from scratch or reused the committed baseline. |
 | `files_written` | sync | The generated files written for the docs commit. |
 | `committed` | sync | `true` when a docs commit was pushed to `target_branch`; `false` when sync mode ran but had nothing to commit (or the push failed open). Empty only if sync mode did not run. |

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
     default: ${{ github.token }}
   push_token:
-    description: 'Token used for git pushes: in review mode the generated .codeboarding/analysis.json to the PR branch (for the webview link), in sync mode the architecture to target_branch. Defaults to the workflow github.token, which can push when the calling workflow grants "permissions: contents: write". Kept separate from github_token so commenting can use a GitHub App token while the push uses the workflow token (whose write access the consumer controls).'
+    description: 'Token used for sync-mode git pushes to target_branch. Defaults to the workflow github.token, which can push when the calling workflow grants "permissions: contents: write". Kept separate from github_token so commenting can use a GitHub App token while the push uses the workflow token (whose write access the consumer controls).'
     required: false
     default: ${{ github.token }}
   engine_ref:
@@ -36,7 +36,7 @@ inputs:
     required: false
     default: 'v0.12.1'
   depth_level:
-    description: 'Analysis depth (1-3). Higher is slower, costlier, and more detailed. Use the SAME value in your review and sync workflows: review mode reuses the committed baseline only when it is no deeper than this, regenerating it otherwise. Lower to 1 for cheaper, faster runs. Empty (default): auto-detect from the committed .codeboarding/analysis.json metadata, falling back to 2.'
+    description: 'Analysis depth (1-3) for cold-start or force_full rebuilds. Once .codeboarding/analysis.json exists, its metadata.depth_level is the source of truth for incremental analysis and fallback-full recovery. Empty (default): 2 for cold starts.'
     required: false
     default: ''
   agent_model:
@@ -68,13 +68,9 @@ inputs:
     required: false
     default: ''
   webview_base_url:
-    description: 'Review mode: base URL of the hosted webview (default https://app.codeboarding.org). The PR comment adds an "explore in browser" link deep-linking to this PR''s head-vs-base architecture diff. Requires the head analysis.json to be committed to the PR branch (commit_head_analysis), so it is omitted on fork PRs. Set empty to disable the webview link.'
+    description: 'Review mode: hosted webview base URL. The PR comment links to an artifact-backed head-vs-base architecture diff; review mode does not commit generated files to PR branches. Set empty to disable the browser link.'
     required: false
     default: 'https://app.codeboarding.org'
-  commit_head_analysis:
-    description: 'Review mode: commit the generated head .codeboarding/analysis.json (+ health report) back to the PR branch so the webview can fetch it at the head SHA. Same-repo PRs only (the token is read-only on forks). Required for the webview "explore in browser" link. Needs contents: write on the workflow.'
-    required: false
-    default: 'true'
   trigger_command:
     description: 'Review mode: slash-command that triggers the action from a PR comment (issue_comment event). A comment whose first word is this runs the diagram on-demand.'
     required: false
@@ -135,6 +131,9 @@ outputs:
   committed:
     description: 'Sync mode: true when a docs commit was created and pushed.'
     value: ${{ steps.sync_commit.outputs.committed }}
+  review_artifact_url:
+    description: 'Review mode: GitHub Actions artifact URL containing PR analysis outputs.'
+    value: ${{ steps.upload_review_artifact.outputs.artifact-url }}
 
 runs:
   using: 'composite'
@@ -145,7 +144,7 @@ runs:
   #   1. GUARD            — resolve mode + event eligibility + SHAs (one source of truth)
   #   2. SHARED SETUP     — checkout engine + target, Python/Node/uv, caches, LLM-key prep
   #   3. ANALYSIS (key live) — review: base/seed/head/health ; sync: seed/analyze
-  #   4. Drop LLM key, then OUTPUT (no key) — review: diff→comment ; sync: render→commit
+  #   4. Drop LLM key, then OUTPUT (no key) — review: diff→artifact→comment ; sync: render→commit
   # The binding between the modes is the committed .codeboarding/analysis.json
   # baseline: sync (phase 3/4) writes it, review (phase 3) reads it as the PR base.
   steps:
@@ -211,7 +210,7 @@ runs:
         esac
         case "$DEPTH" in
           ''|1|2|3) ;;
-          *) echo "::error::depth_level must be 1, 2, or 3 (empty = auto-detect from committed baseline)."; exit 1 ;;
+          *) echo "::error::depth_level must be 1, 2, or 3 (empty = default cold-start depth 2)."; exit 1 ;;
         esac
         echo "mode=$MODE" >> "$GITHUB_OUTPUT"
 
@@ -392,8 +391,8 @@ runs:
         persist-credentials: false
 
     # Review mode: the PR head repo at the head SHA. Sync mode: this repo at the
-    # pushed/selected SHA. Always credential-free — both pushes (head analysis to
-    # the PR branch, docs to target_branch) authenticate explicitly via push_token.
+    # pushed/selected SHA. Always credential-free — sync pushes authenticate
+    # explicitly via push_token.
     - name: Checkout target repository
       if: steps.guard.outputs.skip != 'true'
       uses: actions/checkout@v4
@@ -412,10 +411,10 @@ runs:
         BASE_SHA: ${{ steps.guard.outputs.base_sha }}
         BASE_REPO: ${{ steps.guard.outputs.base_repo }}
       run: |
-        git fetch origin "$BASE_SHA" --depth=1 || true
+        git fetch origin "$BASE_SHA" --depth=2 || true
         if ! git cat-file -e "$BASE_SHA" 2>/dev/null; then
           git remote add base "https://github.com/${BASE_REPO}.git" 2>/dev/null || git remote set-url base "https://github.com/${BASE_REPO}.git"
-          git fetch base "$BASE_SHA" --depth=1 || true
+          git fetch base "$BASE_SHA" --depth=2 || true
         fi
         git cat-file -e "$BASE_SHA" && echo "Base commit reachable." || \
           (echo "::error::Base commit $BASE_SHA is not reachable." && exit 1)
@@ -426,32 +425,18 @@ runs:
       shell: bash
       env:
         INPUT_DEPTH: ${{ inputs.depth_level }}
-        TARGET_REPO: ${{ github.workspace }}/target-repo
-        BASE_SHA: ${{ steps.guard.outputs.base_sha }}
-        MODE: ${{ steps.guard.outputs.mode }}
       run: |
         set -euo pipefail
-        # Explicit input always wins.
+        # Explicit input controls cold-start/force_full rebuilds. Existing
+        # analysis.json metadata is the source of truth for incremental runs.
         if [ -n "$INPUT_DEPTH" ]; then
           echo "depth=$INPUT_DEPTH" >> "$GITHUB_OUTPUT"
           echo "Using explicit depth_level=$INPUT_DEPTH."
           exit 0
         fi
-        # Auto: read from committed analysis.json.
         DEPTH=2
-        if [ "$MODE" = "sync" ]; then
-          if [ -f "$TARGET_REPO/.codeboarding/analysis.json" ]; then
-            DEPTH=$(python3 -c "import json; print(json.load(open('$TARGET_REPO/.codeboarding/analysis.json')).get('metadata',{}).get('depth_level',2))" 2>/dev/null || echo 2)
-          fi
-        else
-          BASE_JSON="$(git -C "$TARGET_REPO" show "${BASE_SHA}:.codeboarding/analysis.json" 2>/dev/null || true)"
-          if [ -n "$BASE_JSON" ]; then
-            DEPTH="$(printf '%s' "$BASE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("metadata",{}).get("depth_level",2))' 2>/dev/null || echo 2)"
-          fi
-        fi
-        case "$DEPTH" in 1|2|3) ;; *) DEPTH=2 ;; esac
         echo "depth=$DEPTH" >> "$GITHUB_OUTPUT"
-        echo "Auto-resolved depth_level=$DEPTH."
+        echo "Using default cold-start depth_level=$DEPTH."
 
     - name: Set up Python 3.13
       if: steps.guard.outputs.skip != 'true'
@@ -673,7 +658,6 @@ runs:
       env:
         BASE_SHA: ${{ steps.guard.outputs.base_sha }}
         ACTION_PATH: ${{ github.action_path }}
-        DEPTH: ${{ steps.resolve_depth.outputs.depth }}
       run: |
         BASE_DIR="${RUNNER_TEMP}/cb-base"
         HEAD_DIR="${RUNNER_TEMP}/cb-head"
@@ -683,8 +667,7 @@ runs:
         if git show "${BASE_SHA}:.codeboarding/analysis.json" > "${BASE_DIR}/analysis.json" 2>/dev/null; then
           if python3 "$ACTION_PATH/scripts/engine_adapter.py" validate-base \
               --analysis "${BASE_DIR}/analysis.json" \
-              --expected-sha "$BASE_SHA" \
-              --expected-depth "$DEPTH"; then
+              --expected-sha "$BASE_SHA"; then
             echo "committed=true" >> $GITHUB_OUTPUT
             echo "Using committed .codeboarding/analysis.json at ${BASE_SHA}."
           else
@@ -944,6 +927,13 @@ runs:
 
         if [ -f "$OUTPUT_DIR/analysis.json" ]; then
           cp "$OUTPUT_DIR/analysis.json" "$ANALYSIS_DIR/analysis.json"
+          if [ -f "$OUTPUT_DIR/static_analysis.pkl" ] && [ -f "$OUTPUT_DIR/static_analysis.sha" ]; then
+            cp "$OUTPUT_DIR/static_analysis.pkl" "$ANALYSIS_DIR/static_analysis.pkl"
+            cp "$OUTPUT_DIR/static_analysis.sha" "$ANALYSIS_DIR/static_analysis.sha"
+            echo "committed_cache=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "committed_cache=false" >> "$GITHUB_OUTPUT"
+          fi
           # baseline-info parses metadata.commit_hash and emits it ONLY when it is
           # present and SHA-shaped, so an unusable/injected value never reaches
           # GITHUB_OUTPUT, the cache key, or git. (Pure stdlib — no engine venv.)
@@ -954,19 +944,21 @@ runs:
             echo "baseline_sha=$BASELINE_SHA" >> "$GITHUB_OUTPUT"
             echo "Using committed baseline generated for $BASELINE_SHA."
           else
-            rm -f "$ANALYSIS_DIR/analysis.json"
+            rm -f "$ANALYSIS_DIR/analysis.json" "$ANALYSIS_DIR/static_analysis.pkl" "$ANALYSIS_DIR/static_analysis.sha"
             echo "baseline_present=false" >> "$GITHUB_OUTPUT"
             echo "baseline_sha=none" >> "$GITHUB_OUTPUT"
+            echo "committed_cache=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Committed analysis.json has no usable metadata.commit_hash; a full analysis will run."
           fi
         else
           echo "baseline_present=false" >> "$GITHUB_OUTPUT"
           echo "baseline_sha=none" >> "$GITHUB_OUTPUT"
+          echo "committed_cache=false" >> "$GITHUB_OUTPUT"
           echo "No committed baseline found; a full analysis will run."
         fi
 
     - name: Restore sync static-analysis cache
-      if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'sync' && steps.sync_seed.outputs.baseline_present == 'true'
+      if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'sync' && steps.sync_seed.outputs.baseline_present == 'true' && steps.sync_seed.outputs.committed_cache != 'true'
       id: sync_cache
       uses: actions/cache/restore@v4
       with:
@@ -979,7 +971,7 @@ runs:
     # analysis.json supplies component ids, but the incremental path also needs
     # the baseline static_analysis.pkl (LSP + clustering, no LLM). Fail-open.
     - name: Seed sync static-analysis cache at baseline SHA
-      if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'sync' && steps.sync_seed.outputs.baseline_present == 'true' && steps.sync_cache.outputs.cache-hit != 'true'
+      if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'sync' && steps.sync_seed.outputs.baseline_present == 'true' && steps.sync_seed.outputs.committed_cache != 'true' && steps.sync_cache.outputs.cache-hit != 'true'
       id: sync_seedcache
       continue-on-error: true
       shell: bash
@@ -1091,83 +1083,6 @@ runs:
               "${RUNNER_TEMP}/cb-agent-model" \
               "${RUNNER_TEMP}/cb-parsing-model"
 
-    # Commit the generated head analysis (+ health report) to the PR branch so the
-    # hosted webview can fetch .codeboarding/analysis.json at the head SHA and open
-    # this PR's head-vs-base diff. Same-repo PRs only — the token is read-only on
-    # forks (the step is skipped there and the webview link is omitted). The push
-    # creates a NEW head commit; its SHA (webview_sha) is what the comment links to.
-    - name: Commit head analysis to PR branch
-      id: commit_head
-      if: >-
-        steps.guard.outputs.skip != 'true'
-        && steps.guard.outputs.mode == 'review'
-        && inputs.commit_head_analysis == 'true'
-        && steps.guard.outputs.same_repo == 'true'
-        && inputs.webview_base_url != ''
-      shell: bash
-      working-directory: target-repo
-      env:
-        # Push with push_token (defaults to the workflow github.token, gated by the
-        # consumer's `permissions: contents: write`) — NOT github_token, which may be
-        # a GitHub App token used only for commenting and need not have write access.
-        GH_TOKEN: ${{ inputs.push_token }}
-        HEAD_DIR: ${{ steps.base.outputs.head_dir }}
-        HEAD_REF: ${{ steps.guard.outputs.head_ref }}
-        HEAD_SHA: ${{ steps.guard.outputs.head_sha }}
-        REPOSITORY: ${{ github.repository }}
-        SERVER_URL: ${{ github.server_url }}
-      run: |
-        echo "ready=false" >> "$GITHUB_OUTPUT"
-        echo "webview_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-        [ -n "$HEAD_REF" ] || { echo "::notice::No head branch ref resolved; skipping head-analysis commit."; exit 0; }
-        [ -f "$HEAD_DIR/analysis.json" ] || { echo "::notice::No head analysis.json to commit."; exit 0; }
-
-        mkdir -p .codeboarding/health
-        cp "$HEAD_DIR/analysis.json" .codeboarding/analysis.json
-        if [ -f "$HEAD_DIR/health/health_report.json" ]; then
-          cp "$HEAD_DIR/health/health_report.json" .codeboarding/health/health_report.json
-        fi
-
-        git add .codeboarding/analysis.json .codeboarding/health/health_report.json 2>/dev/null || git add .codeboarding/analysis.json
-        if git diff --cached --quiet; then
-          echo "::notice::Head analysis unchanged; nothing to commit."
-          echo "ready=true" >> "$GITHUB_OUTPUT"   # already committed at this SHA → webview can read it
-          exit 0
-        fi
-        # Same architecture, only volatile metadata differs: don't commit. The
-        # ignored fields must cover EVERY per-run field, or the loop below stays
-        # open: generated_at and the health timestamp, AND commit_hash — which
-        # tracks the analyzed head SHA, so on a synchronize re-run (whose head IS
-        # our previous bot commit) it changes even when the architecture didn't.
-        # The bot commit carries no "[skip ci]" (it would leak through squash-
-        # merges and skip real merges' workflows), so without ignoring all three
-        # a synchronize-triggered re-run would re-commit a fresh SHA/timestamp
-        # forever. ready=true: the analysis already committed serves the webview.
-        if git diff --cached --quiet -I '"generated_at"' -I '"timestamp"' -I '"commit_hash"'; then
-          git reset -q
-          echo "::notice::Head analysis differs only in volatile metadata (timestamps/commit_hash); nothing to commit."
-          echo "ready=true" >> "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
-        git config user.name "codeboarding[bot]"
-        git config user.email "codeboarding[bot]@users.noreply.github.com"
-        git commit -m "chore(codeboarding): update architecture analysis" >/dev/null
-
-        # Push to the PR head branch. The checkout used persist-credentials:false, so
-        # authenticate the push explicitly with the workflow token (same-repo only).
-        # Requires `contents: write` on the job's token — a read-only token (the
-        # default) is rejected here; the push error below names the cause.
-        AUTH_URL="https://x-access-token:${GH_TOKEN}@${SERVER_URL#https://}/${REPOSITORY}.git"
-        if git push "$AUTH_URL" "HEAD:refs/heads/${HEAD_REF}"; then
-          NEW_SHA="$(git rev-parse HEAD)"
-          echo "webview_sha=$NEW_SHA" >> "$GITHUB_OUTPUT"
-          echo "ready=true" >> "$GITHUB_OUTPUT"
-          echo "Committed head analysis to ${HEAD_REF} as ${NEW_SHA}."
-        else
-          echo "::warning::Could not push head analysis to ${HEAD_REF}; the webview link will be omitted. Most likely the job's token lacks 'contents: write' (add 'permissions: contents: write' to the calling workflow), or the branch is protected against this pusher."
-        fi
-
     - name: Diff analyses → Mermaid
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review'
       id: diagram
@@ -1206,6 +1121,58 @@ runs:
         echo "truncated=$TRUNCATED" >> $GITHUB_OUTPUT
         echo "diagram_md=${RUNNER_TEMP}/diagram.md" >> $GITHUB_OUTPUT
 
+    - name: Prepare PR analysis artifact
+      if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review'
+      id: review_artifact
+      shell: bash
+      env:
+        BASE_ANALYSIS: ${{ steps.analyze.outputs.base_analysis }}
+        HEAD_ANALYSIS: ${{ steps.analyze.outputs.head_analysis }}
+        HEAD_DIR: ${{ steps.base.outputs.head_dir }}
+        DIAGRAM_MD: ${{ steps.diagram.outputs.diagram_md }}
+        BASE_SHA: ${{ steps.guard.outputs.base_sha }}
+        HEAD_SHA: ${{ steps.guard.outputs.head_sha }}
+        PR: ${{ steps.guard.outputs.pr_number }}
+        OWNER_REPO: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
+        RUN_ATTEMPT: ${{ github.run_attempt }}
+      run: |
+        set -euo pipefail
+        ARTIFACT_DIR="${RUNNER_TEMP}/codeboarding-pr-artifact"
+        ARTIFACT_NAME="codeboarding-pr-${PR}-${HEAD_SHA}"
+        export ARTIFACT_NAME
+        rm -rf "$ARTIFACT_DIR"
+        mkdir -p "$ARTIFACT_DIR/base" "$ARTIFACT_DIR/head/health"
+        cp "$BASE_ANALYSIS" "$ARTIFACT_DIR/base/analysis.json"
+        cp "$HEAD_ANALYSIS" "$ARTIFACT_DIR/head/analysis.json"
+        [ -f "$HEAD_DIR/health/health_report.json" ] && cp "$HEAD_DIR/health/health_report.json" "$ARTIFACT_DIR/head/health/health_report.json"
+        [ -f "$DIAGRAM_MD" ] && cp "$DIAGRAM_MD" "$ARTIFACT_DIR/diagram.md"
+        [ -f "${RUNNER_TEMP}/diagram_meta.json" ] && cp "${RUNNER_TEMP}/diagram_meta.json" "$ARTIFACT_DIR/diagram_meta.json"
+        python3 - <<'PY' > "$ARTIFACT_DIR/metadata.json"
+        import json, os
+
+        print(json.dumps({
+            "repository": os.environ["OWNER_REPO"],
+            "pr": os.environ["PR"],
+            "base_sha": os.environ["BASE_SHA"],
+            "head_sha": os.environ["HEAD_SHA"],
+            "run_id": os.environ["RUN_ID"],
+            "run_attempt": os.environ["RUN_ATTEMPT"],
+            "artifact_name": os.environ["ARTIFACT_NAME"],
+        }, indent=2))
+        PY
+        echo "path=$ARTIFACT_DIR" >> "$GITHUB_OUTPUT"
+        echo "name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+
+    - name: Upload PR analysis artifact
+      if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review'
+      id: upload_review_artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ steps.review_artifact.outputs.name }}
+        path: ${{ steps.review_artifact.outputs.path }}
+        retention-days: 14
+
     - name: Build PR comment body
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review'
       id: body
@@ -1229,10 +1196,9 @@ runs:
         PR: ${{ steps.guard.outputs.pr_number }}
         ISSUES: ${{ steps.health.outputs.issues }}
         WEBVIEW_BASE: ${{ inputs.webview_base_url }}
-        # SHA the head analysis.json was committed at (post-push), and whether that
-        # commit succeeded — gates the webview "explore in browser" link.
-        WEBVIEW_SHA: ${{ steps.commit_head.outputs.webview_sha }}
-        WEBVIEW_READY: ${{ steps.commit_head.outputs.ready }}
+        HEAD_SHA: ${{ steps.guard.outputs.head_sha }}
+        ARTIFACT_NAME: ${{ steps.review_artifact.outputs.name }}
+        ARTIFACT_URL: ${{ steps.upload_review_artifact.outputs.artifact-url }}
         BASE_SHA: ${{ steps.guard.outputs.base_sha }}
       run: |
         BODY_FILE=$(mktemp)
@@ -1245,14 +1211,21 @@ runs:
           else echo "$CHANGED_COUNT components changed"; fi
         }
 
-        # CTA footer: an editor link (proxy deep-link when CTA_BASE is set, else the
-        # extension's https listing — GitHub strips vscode:/cursor:), the ⚠️ banner,
-        # and — when the head analysis was committed (WEBVIEW_READY) — a webview
-        # "explore in browser" link to this PR's head-vs-base diff.
+        # CTA footer: a hosted webview browser link backed by the uploaded PR
+        # artifact, editor link(s), and the ⚠️ banner. PR analysis data is not
+        # committed to the PR branch.
         cta() {
           local extra=()
-          if [ "$WEBVIEW_READY" = "true" ]; then
-            extra+=(--webview-ready --webview-base "$WEBVIEW_BASE" --head-sha "$WEBVIEW_SHA" --base-sha "$BASE_SHA")
+          if [ -n "$WEBVIEW_BASE" ] && [ -n "$ARTIFACT_NAME" ]; then
+            extra+=(
+              --webview-ready
+              --webview-base "$WEBVIEW_BASE"
+              --head-sha "$HEAD_SHA"
+              --base-sha "$BASE_SHA"
+              --run-id "$RUN_ID"
+              --artifact-name "$ARTIFACT_NAME"
+              --artifact-url "$ARTIFACT_URL"
+            )
           fi
           python3 "$ACTION_PATH/scripts/build_cta.py" \
             --cta-base "$CTA_BASE" --owner "$OWNER" --repo "$REPO" --pr "$PR" \
@@ -1295,6 +1268,10 @@ runs:
             echo "Architecture changed versus \`${BASE_REF}\`, but the diagram is too large to render inline (GitHub caps inline Mermaid at ~500 edges)."
           else
             echo "No architectural changes detected versus \`${BASE_REF}\`."
+          fi
+          if [ -n "$ARTIFACT_URL" ]; then
+            echo ""
+            echo "Download the PR analysis artifacts from this workflow [artifact](${ARTIFACT_URL})."
           fi
           if [ -s "$FILES_MD" ]; then
             echo ""
@@ -1421,6 +1398,12 @@ runs:
         fi
         cp "${rendered[@]}" "$OUTPUT_DIR/"
         cp "$ANALYSIS_DIR/analysis.json" "$OUTPUT_DIR/analysis.json"
+        if [ -f "$ANALYSIS_DIR/static_analysis.pkl" ] && [ -f "$ANALYSIS_DIR/static_analysis.sha" ]; then
+          cp "$ANALYSIS_DIR/static_analysis.pkl" "$OUTPUT_DIR/static_analysis.pkl"
+          cp "$ANALYSIS_DIR/static_analysis.sha" "$OUTPUT_DIR/static_analysis.sha"
+        else
+          rm -f "$OUTPUT_DIR/static_analysis.pkl" "$OUTPUT_DIR/static_analysis.sha"
+        fi
         if [ -f "$ANALYSIS_DIR/codeboarding_version.json" ]; then
           cp "$ANALYSIS_DIR/codeboarding_version.json" "$OUTPUT_DIR/codeboarding_version.json"
         fi
@@ -1434,6 +1417,13 @@ runs:
 
         new_md=("$OUTPUT_DIR"/*"$OUTPUT_FORMAT")
         stage_paths=("$OUTPUT_DIR/analysis.json")
+        add_if_present_or_tracked() {
+          if [ -e "$1" ] || git ls-files --error-unmatch "$1" >/dev/null 2>&1; then
+            stage_paths+=("$1")
+          fi
+        }
+        add_if_present_or_tracked "$OUTPUT_DIR/static_analysis.pkl"
+        add_if_present_or_tracked "$OUTPUT_DIR/static_analysis.sha"
         [ -f "$OUTPUT_DIR/codeboarding_version.json" ] && stage_paths+=("$OUTPUT_DIR/codeboarding_version.json")
         [ -f "$OUTPUT_DIR/health/health_report.json" ] && stage_paths+=("$OUTPUT_DIR/health/health_report.json")
         if [ "$WRITE_ARCHITECTURE_MD" = "true" ]; then

--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,7 @@ outputs:
     description: 'Sync mode: true when a docs commit was created and pushed.'
     value: ${{ steps.sync_commit.outputs.committed }}
   review_artifact_url:
-    description: 'Review mode: GitHub Actions artifact URL containing PR analysis outputs.'
+    description: 'Review mode: GitHub Actions artifact URL containing the PR-head analysis.json and metadata.'
     value: ${{ steps.upload_review_artifact.outputs.artifact-url }}
 
 runs:
@@ -1126,11 +1126,10 @@ runs:
       id: review_artifact
       shell: bash
       env:
-        BASE_ANALYSIS: ${{ steps.analyze.outputs.base_analysis }}
         HEAD_ANALYSIS: ${{ steps.analyze.outputs.head_analysis }}
-        HEAD_DIR: ${{ steps.base.outputs.head_dir }}
-        DIAGRAM_MD: ${{ steps.diagram.outputs.diagram_md }}
         BASE_SHA: ${{ steps.guard.outputs.base_sha }}
+        BASELINE_SHA: ${{ steps.base.outputs.baseline_sha }}
+        BASELINE_COMMITTED: ${{ steps.base.outputs.committed }}
         HEAD_SHA: ${{ steps.guard.outputs.head_sha }}
         PR: ${{ steps.guard.outputs.pr_number }}
         OWNER_REPO: ${{ github.repository }}
@@ -1142,19 +1141,18 @@ runs:
         ARTIFACT_NAME="codeboarding-pr-${PR}-${HEAD_SHA}"
         export ARTIFACT_NAME
         rm -rf "$ARTIFACT_DIR"
-        mkdir -p "$ARTIFACT_DIR/base" "$ARTIFACT_DIR/head/health"
-        cp "$BASE_ANALYSIS" "$ARTIFACT_DIR/base/analysis.json"
-        cp "$HEAD_ANALYSIS" "$ARTIFACT_DIR/head/analysis.json"
-        [ -f "$HEAD_DIR/health/health_report.json" ] && cp "$HEAD_DIR/health/health_report.json" "$ARTIFACT_DIR/head/health/health_report.json"
-        [ -f "$DIAGRAM_MD" ] && cp "$DIAGRAM_MD" "$ARTIFACT_DIR/diagram.md"
-        [ -f "${RUNNER_TEMP}/diagram_meta.json" ] && cp "${RUNNER_TEMP}/diagram_meta.json" "$ARTIFACT_DIR/diagram_meta.json"
+        mkdir -p "$ARTIFACT_DIR"
+        cp "$HEAD_ANALYSIS" "$ARTIFACT_DIR/analysis.json"
         python3 - <<'PY' > "$ARTIFACT_DIR/metadata.json"
         import json, os
 
+        baseline_committed = os.environ["BASELINE_COMMITTED"] == "true"
         print(json.dumps({
             "repository": os.environ["OWNER_REPO"],
             "pr": os.environ["PR"],
-            "base_sha": os.environ["BASE_SHA"],
+            "pr_base_sha": os.environ["BASE_SHA"],
+            "base_commit_sha": os.environ["BASELINE_SHA"] if baseline_committed else None,
+            "base_commit_found": baseline_committed,
             "head_sha": os.environ["HEAD_SHA"],
             "run_id": os.environ["RUN_ID"],
             "run_attempt": os.environ["RUN_ATTEMPT"],

--- a/action.yml
+++ b/action.yml
@@ -1455,7 +1455,7 @@ runs:
           stage_paths+=("docs/development/architecture.md")
         fi
         stage_paths+=("${old_md[@]}" "${new_md[@]}")
-        git add -A -- "${stage_paths[@]}"
+        git add -f -A -- "${stage_paths[@]}"
 
         if git diff --cached --quiet; then
           echo "::notice::Generated architecture is unchanged; nothing to commit."

--- a/action.yml
+++ b/action.yml
@@ -36,9 +36,9 @@ inputs:
     required: false
     default: 'v0.12.1'
   depth_level:
-    description: 'Analysis depth (1-3). Higher is slower, costlier, and more detailed. Use the SAME value in your review and sync workflows: review mode reuses the committed baseline only when it is no deeper than this, regenerating it otherwise. Lower to 1 for cheaper, faster runs.'
+    description: 'Analysis depth (1-3). Higher is slower, costlier, and more detailed. Use the SAME value in your review and sync workflows: review mode reuses the committed baseline only when it is no deeper than this, regenerating it otherwise. Lower to 1 for cheaper, faster runs. Empty (default): auto-detect from the committed .codeboarding/analysis.json metadata, falling back to 2.'
     required: false
-    default: '2'
+    default: ''
   agent_model:
     description: 'Analysis model (AGENT_MODEL env var). A bare OpenRouter slug. Defaults to google/gemini-3-flash-preview on OpenRouter; for other providers, empty uses the engine''s per-provider default.'
     required: false
@@ -210,8 +210,8 @@ runs:
           *) echo "::error::mode must be 'review' or 'sync' (got '$MODE')."; exit 1 ;;
         esac
         case "$DEPTH" in
-          1|2|3) ;;
-          *) echo "::error::depth_level must be 1, 2, or 3."; exit 1 ;;
+          ''|1|2|3) ;;
+          *) echo "::error::depth_level must be 1, 2, or 3 (empty = auto-detect from committed baseline)."; exit 1 ;;
         esac
         echo "mode=$MODE" >> "$GITHUB_OUTPUT"
 
@@ -419,6 +419,39 @@ runs:
         fi
         git cat-file -e "$BASE_SHA" && echo "Base commit reachable." || \
           (echo "::error::Base commit $BASE_SHA is not reachable." && exit 1)
+
+    - name: Resolve analysis depth
+      id: resolve_depth
+      if: steps.guard.outputs.skip != 'true'
+      shell: bash
+      env:
+        INPUT_DEPTH: ${{ inputs.depth_level }}
+        TARGET_REPO: ${{ github.workspace }}/target-repo
+        BASE_SHA: ${{ steps.guard.outputs.base_sha }}
+        MODE: ${{ steps.guard.outputs.mode }}
+      run: |
+        set -euo pipefail
+        # Explicit input always wins.
+        if [ -n "$INPUT_DEPTH" ]; then
+          echo "depth=$INPUT_DEPTH" >> "$GITHUB_OUTPUT"
+          echo "Using explicit depth_level=$INPUT_DEPTH."
+          exit 0
+        fi
+        # Auto: read from committed analysis.json.
+        DEPTH=2
+        if [ "$MODE" = "sync" ]; then
+          if [ -f "$TARGET_REPO/.codeboarding/analysis.json" ]; then
+            DEPTH=$(python3 -c "import json; print(json.load(open('$TARGET_REPO/.codeboarding/analysis.json')).get('metadata',{}).get('depth_level',2))" 2>/dev/null || echo 2)
+          fi
+        else
+          BASE_JSON="$(git -C "$TARGET_REPO" show "${BASE_SHA}:.codeboarding/analysis.json" 2>/dev/null || true)"
+          if [ -n "$BASE_JSON" ]; then
+            DEPTH="$(printf '%s' "$BASE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("metadata",{}).get("depth_level",2))' 2>/dev/null || echo 2)"
+          fi
+        fi
+        case "$DEPTH" in 1|2|3) ;; *) DEPTH=2 ;; esac
+        echo "depth=$DEPTH" >> "$GITHUB_OUTPUT"
+        echo "Auto-resolved depth_level=$DEPTH."
 
     - name: Set up Python 3.13
       if: steps.guard.outputs.skip != 'true'
@@ -640,7 +673,7 @@ runs:
       env:
         BASE_SHA: ${{ steps.guard.outputs.base_sha }}
         ACTION_PATH: ${{ github.action_path }}
-        DEPTH: ${{ inputs.depth_level }}
+        DEPTH: ${{ steps.resolve_depth.outputs.depth }}
       run: |
         BASE_DIR="${RUNNER_TEMP}/cb-base"
         HEAD_DIR="${RUNNER_TEMP}/cb-head"
@@ -677,7 +710,7 @@ runs:
         # inputs. So a free-tier run (oidc, forced Gemini) and a BYO OpenRouter-key
         # run with no model pinned would share a key yet produce different base
         # analyses; the mode discriminator keeps them from reusing each other's cache.
-        key: cb-base-v2-${{ runner.os }}-${{ steps.guard.outputs.base_sha }}-d${{ inputs.depth_level }}-${{ inputs.engine_ref }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
+        key: cb-base-v2-${{ runner.os }}-${{ steps.guard.outputs.base_sha }}-d${{ steps.resolve_depth.outputs.depth }}-${{ inputs.engine_ref }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
 
     # A committed analysis.json gives the head analysis stable component ids,
     # but the engine's incremental path ALSO needs the base static_analysis.pkl
@@ -731,7 +764,7 @@ runs:
       env:
         STATIC_ANALYSIS_CONFIG: ${{ github.workspace }}/codeboarding-engine/static_analysis_config.yml
         PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
-        DIAGRAM_DEPTH_LEVEL: ${{ inputs.depth_level }}
+        DIAGRAM_DEPTH_LEVEL: ${{ steps.resolve_depth.outputs.depth }}
         CACHING_DOCUMENTATION: 'false'
         ENABLE_MONITORING: 'false'
         ACTION_PATH: ${{ github.action_path }}
@@ -739,7 +772,7 @@ runs:
         BASE_DIR: ${{ steps.base.outputs.base_dir }}
         REPO_NAME: ${{ github.event.repository.name }}
         RUN_ID_BASE: ${{ github.run_id }}-${{ github.run_attempt }}-base
-        DEPTH: ${{ inputs.depth_level }}
+        DEPTH: ${{ steps.resolve_depth.outputs.depth }}
         BASE_SHA: ${{ steps.guard.outputs.base_sha }}
       run: |
         # Export the key under the selected provider's env var (only this one),
@@ -796,7 +829,7 @@ runs:
         # inputs. So a free-tier run (oidc, forced Gemini) and a BYO OpenRouter-key
         # run with no model pinned would share a key yet produce different base
         # analyses; the mode discriminator keeps them from reusing each other's cache.
-        key: cb-base-v2-${{ runner.os }}-${{ steps.guard.outputs.base_sha }}-d${{ inputs.depth_level }}-${{ inputs.engine_ref }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
+        key: cb-base-v2-${{ runner.os }}-${{ steps.guard.outputs.base_sha }}-d${{ steps.resolve_depth.outputs.depth }}-${{ inputs.engine_ref }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
 
     - name: Analyze PR head (incremental from base)
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review'
@@ -806,7 +839,7 @@ runs:
       env:
         STATIC_ANALYSIS_CONFIG: ${{ github.workspace }}/codeboarding-engine/static_analysis_config.yml
         PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
-        DIAGRAM_DEPTH_LEVEL: ${{ inputs.depth_level }}
+        DIAGRAM_DEPTH_LEVEL: ${{ steps.resolve_depth.outputs.depth }}
         CACHING_DOCUMENTATION: 'false'
         ENABLE_MONITORING: 'false'
         ACTION_PATH: ${{ github.action_path }}
@@ -815,7 +848,7 @@ runs:
         HEAD_DIR: ${{ steps.base.outputs.head_dir }}
         REPO_NAME: ${{ github.event.repository.name }}
         RUN_ID_HEAD: ${{ github.run_id }}-${{ github.run_attempt }}-head
-        DEPTH: ${{ inputs.depth_level }}
+        DEPTH: ${{ steps.resolve_depth.outputs.depth }}
         BASE_SHA: ${{ steps.guard.outputs.base_sha }}
         HEAD_SHA: ${{ steps.guard.outputs.head_sha }}
       run: |
@@ -940,7 +973,7 @@ runs:
         path: |
           ${{ runner.temp }}/cb-sync/static_analysis.pkl
           ${{ runner.temp }}/cb-sync/static_analysis.sha
-        key: cb-sync-${{ runner.os }}-${{ inputs.engine_ref }}-d${{ inputs.depth_level }}-${{ steps.llm.outputs.cache_provider }}-${{ steps.llm.outputs.cache_agent_model }}-${{ steps.llm.outputs.cache_parsing_model }}-${{ steps.sync_seed.outputs.baseline_sha }}
+        key: cb-sync-${{ runner.os }}-${{ inputs.engine_ref }}-d${{ steps.resolve_depth.outputs.depth }}-${{ steps.llm.outputs.cache_provider }}-${{ steps.llm.outputs.cache_agent_model }}-${{ steps.llm.outputs.cache_parsing_model }}-${{ steps.sync_seed.outputs.baseline_sha }}
 
     # Same rationale as the review pipeline's seed step: the committed
     # analysis.json supplies component ids, but the incremental path also needs
@@ -999,7 +1032,7 @@ runs:
       env:
         STATIC_ANALYSIS_CONFIG: ${{ github.workspace }}/codeboarding-engine/static_analysis_config.yml
         PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
-        DIAGRAM_DEPTH_LEVEL: ${{ inputs.depth_level }}
+        DIAGRAM_DEPTH_LEVEL: ${{ steps.resolve_depth.outputs.depth }}
         CACHING_DOCUMENTATION: 'false'
         ENABLE_MONITORING: 'false'
         ACTION_PATH: ${{ github.action_path }}
@@ -1008,7 +1041,7 @@ runs:
         REPO_NAME: ${{ github.event.repository.name }}
         RUN_ID_SYNC: ${{ github.run_id }}-${{ github.run_attempt }}-sync
         TARGET_SHA: ${{ steps.guard.outputs.target_sha }}
-        DEPTH: ${{ inputs.depth_level }}
+        DEPTH: ${{ steps.resolve_depth.outputs.depth }}
         FORCE_FULL: ${{ inputs.force_full }}
       run: |
         set -euo pipefail
@@ -1342,7 +1375,7 @@ runs:
         path: |
           ${{ runner.temp }}/cb-sync/static_analysis.pkl
           ${{ runner.temp }}/cb-sync/static_analysis.sha
-        key: cb-sync-${{ runner.os }}-${{ inputs.engine_ref }}-d${{ inputs.depth_level }}-${{ steps.llm.outputs.cache_provider }}-${{ steps.llm.outputs.cache_agent_model }}-${{ steps.llm.outputs.cache_parsing_model }}-${{ steps.guard.outputs.target_sha }}
+        key: cb-sync-${{ runner.os }}-${{ inputs.engine_ref }}-d${{ steps.resolve_depth.outputs.depth }}-${{ steps.llm.outputs.cache_provider }}-${{ steps.llm.outputs.cache_agent_model }}-${{ steps.llm.outputs.cache_parsing_model }}-${{ steps.guard.outputs.target_sha }}
 
     - name: Commit and push synced architecture
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'sync'
@@ -1466,7 +1499,7 @@ runs:
       env:
         START_TS: ${{ steps.guard.outputs.start_ts }}
         MODE: ${{ steps.sync_analyze.outputs.analysis_mode }}
-        DEPTH: ${{ inputs.depth_level }}
+        DEPTH: ${{ steps.resolve_depth.outputs.depth }}
         FILES_WRITTEN: ${{ steps.sync_commit.outputs.files_written }}
         COMMITTED: ${{ steps.sync_commit.outputs.committed }}
         PUSHED_SHA: ${{ steps.sync_commit.outputs.pushed_sha }}

--- a/action.yml
+++ b/action.yml
@@ -403,14 +403,22 @@ runs:
         ref: ${{ steps.guard.outputs.checkout_sha }}
         persist-credentials: false
 
-    - name: Ensure PR base commit is fetched
+    - name: Ensure PR comparison commits are fetched
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review'
       shell: bash
       working-directory: target-repo
       env:
         BASE_SHA: ${{ steps.guard.outputs.base_sha }}
         BASE_REPO: ${{ steps.guard.outputs.base_repo }}
+        BASE_REF: ${{ steps.guard.outputs.base_ref }}
       run: |
+        git remote add base "https://github.com/${BASE_REPO}.git" 2>/dev/null || git remote set-url base "https://github.com/${BASE_REPO}.git"
+        # The baseline search walks the PR head ancestry, which checkout fetched
+        # with fetch-depth: 0. We still fetch the PR base commit for GitHub-style
+        # changed-file diffs and for the no-baseline fallback full base analysis.
+        if [ -n "$BASE_REF" ]; then
+          git fetch --no-tags base "+refs/heads/${BASE_REF}:refs/remotes/codeboarding-base/${BASE_REF}" || true
+        fi
         git fetch origin "$BASE_SHA" --depth=2 || true
         if ! git cat-file -e "$BASE_SHA" 2>/dev/null; then
           git remote add base "https://github.com/${BASE_REPO}.git" 2>/dev/null || git remote set-url base "https://github.com/${BASE_REPO}.git"
@@ -657,6 +665,7 @@ runs:
       working-directory: target-repo
       env:
         BASE_SHA: ${{ steps.guard.outputs.base_sha }}
+        HEAD_SHA: ${{ steps.guard.outputs.head_sha }}
         ACTION_PATH: ${{ github.action_path }}
       run: |
         BASE_DIR="${RUNNER_TEMP}/cb-base"
@@ -664,24 +673,42 @@ runs:
         mkdir -p "$BASE_DIR" "$HEAD_DIR"
         echo "base_dir=$BASE_DIR" >> $GITHUB_OUTPUT
         echo "head_dir=$HEAD_DIR" >> $GITHUB_OUTPUT
-        if git show "${BASE_SHA}:.codeboarding/analysis.json" > "${BASE_DIR}/analysis.json" 2>/dev/null; then
+        BASELINE_SHA=""
+        # Use the newest analysis.json reachable by walking backwards through
+        # the PR head branch ancestry. If the PR branch is a->b->c->d and master
+        # is a->b->m1->m2, this deliberately searches d,c,b,a — not m2,m1,b,a.
+        while IFS= read -r candidate; do
+          if git cat-file -e "${candidate}:.codeboarding/analysis.json" 2>/dev/null; then
+            BASELINE_SHA="$candidate"
+            break
+          fi
+        done < <(git rev-list "$HEAD_SHA" -- .codeboarding/analysis.json 2>/dev/null || true)
+
+        if [ -n "$BASELINE_SHA" ] && git show "${BASELINE_SHA}:.codeboarding/analysis.json" > "${BASE_DIR}/analysis.json" 2>/dev/null; then
           if python3 "$ACTION_PATH/scripts/engine_adapter.py" validate-base \
               --analysis "${BASE_DIR}/analysis.json" \
-              --expected-sha "$BASE_SHA"; then
+              --expected-sha "$BASELINE_SHA"; then
             echo "committed=true" >> $GITHUB_OUTPUT
-            echo "Using committed .codeboarding/analysis.json at ${BASE_SHA}."
+            echo "baseline_sha=$BASELINE_SHA" >> $GITHUB_OUTPUT
+            if [ "$BASELINE_SHA" = "$HEAD_SHA" ]; then
+              echo "Using committed .codeboarding/analysis.json at PR head ${HEAD_SHA}."
+            else
+              echo "Using nearest committed .codeboarding/analysis.json at ${BASELINE_SHA} from PR head history ${HEAD_SHA}."
+            fi
           else
             rm -f "${BASE_DIR}/analysis.json"
             echo "committed=false" >> $GITHUB_OUTPUT
-            echo "Committed baseline at ${BASE_SHA} is stale; will generate a fresh base analysis."
+            echo "baseline_sha=$BASE_SHA" >> $GITHUB_OUTPUT
+            echo "Committed baseline at ${BASELINE_SHA} is unusable; will generate a fresh base analysis at ${BASE_SHA}."
           fi
         else
           rm -f "${BASE_DIR}/analysis.json"
           echo "committed=false" >> $GITHUB_OUTPUT
-          echo "No committed baseline at ${BASE_SHA}; will generate one via a full analysis on the base commit."
+          echo "baseline_sha=$BASE_SHA" >> $GITHUB_OUTPUT
+          echo "No committed baseline found in PR head history; will generate one via a full analysis on the base commit ${BASE_SHA}."
         fi
 
-    - name: Restore base artifacts (keyed by base SHA)
+    - name: Restore base artifacts (keyed by baseline SHA)
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review'
       id: basecache
       uses: actions/cache/restore@v4
@@ -693,7 +720,7 @@ runs:
         # inputs. So a free-tier run (oidc, forced Gemini) and a BYO OpenRouter-key
         # run with no model pinned would share a key yet produce different base
         # analyses; the mode discriminator keeps them from reusing each other's cache.
-        key: cb-base-v2-${{ runner.os }}-${{ steps.guard.outputs.base_sha }}-d${{ steps.resolve_depth.outputs.depth }}-${{ inputs.engine_ref }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
+        key: cb-base-v2-${{ runner.os }}-${{ steps.base.outputs.baseline_sha }}-d${{ steps.resolve_depth.outputs.depth }}-${{ inputs.engine_ref }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
 
     # A committed analysis.json gives the head analysis stable component ids,
     # but the engine's incremental path ALSO needs the base static_analysis.pkl
@@ -715,7 +742,7 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
         TARGET: ${{ github.workspace }}/target-repo
         BASE_DIR: ${{ steps.base.outputs.base_dir }}
-        BASE_SHA: ${{ steps.guard.outputs.base_sha }}
+        BASELINE_SHA: ${{ steps.base.outputs.baseline_sha }}
       run: |
         # Clean up any stale registration before re-adding (rm -rf alone leaves a
         # dangling worktree entry that makes a retry's `worktree add` fail).
@@ -723,14 +750,14 @@ runs:
         git -C "$TARGET" worktree remove --force "$BASE_SRC" 2>/dev/null || true
         git -C "$TARGET" worktree prune
         rm -rf "$BASE_SRC"
-        git -C "$TARGET" worktree add --detach "$BASE_SRC" "$BASE_SHA"
+        git -C "$TARGET" worktree add --detach "$BASE_SRC" "$BASELINE_SHA"
         if uv run python "$ACTION_PATH/scripts/engine_adapter.py" seed \
              --repo "$BASE_SRC" \
              --out "$BASE_DIR" \
-             --source-sha "$BASE_SHA" \
+             --source-sha "$BASELINE_SHA" \
            && [ -f "$BASE_DIR/static_analysis.pkl" ] && [ -f "$BASE_DIR/static_analysis.sha" ]; then
           echo "seed_ok=true" >> "$GITHUB_OUTPUT"
-          echo "::notice::Seeded base static-analysis cache for ${BASE_SHA}; head analysis can run incrementally."
+          echo "::notice::Seeded base static-analysis cache for ${BASELINE_SHA}; head analysis can run incrementally."
         else
           # Never leave a partial pkl/sha pair behind: the save step below would
           # cache it under this base SHA's key and suppress every retry.
@@ -812,7 +839,7 @@ runs:
         # inputs. So a free-tier run (oidc, forced Gemini) and a BYO OpenRouter-key
         # run with no model pinned would share a key yet produce different base
         # analyses; the mode discriminator keeps them from reusing each other's cache.
-        key: cb-base-v2-${{ runner.os }}-${{ steps.guard.outputs.base_sha }}-d${{ steps.resolve_depth.outputs.depth }}-${{ inputs.engine_ref }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
+        key: cb-base-v2-${{ runner.os }}-${{ steps.base.outputs.baseline_sha }}-d${{ steps.resolve_depth.outputs.depth }}-${{ inputs.engine_ref }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
 
     - name: Analyze PR head (incremental from base)
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review'
@@ -832,7 +859,7 @@ runs:
         REPO_NAME: ${{ github.event.repository.name }}
         RUN_ID_HEAD: ${{ github.run_id }}-${{ github.run_attempt }}-head
         DEPTH: ${{ steps.resolve_depth.outputs.depth }}
-        BASE_SHA: ${{ steps.guard.outputs.base_sha }}
+        BASELINE_SHA: ${{ steps.base.outputs.baseline_sha }}
         HEAD_SHA: ${{ steps.guard.outputs.head_sha }}
       run: |
         # Export the key under the selected provider's env var (only this one),
@@ -865,7 +892,7 @@ runs:
           --name "$REPO_NAME" \
           --run-id "$RUN_ID_HEAD" \
           --depth "$DEPTH" \
-          --base-ref "$BASE_SHA" \
+          --base-ref "$BASELINE_SHA" \
           --target-ref "$HEAD_SHA" \
           --source-sha "$HEAD_SHA"
         if [ ! -f "$HEAD_DIR/analysis.json" ]; then

--- a/docs/COMMIT_STRATEGY.md
+++ b/docs/COMMIT_STRATEGY.md
@@ -1,7 +1,7 @@
 # Baseline & artifact commit strategy
 
-What CodeBoarding writes into a repo, what we commit vs. cache, where, and how
-today's choice keeps a future hosted-webview viewer possible without rework.
+What CodeBoarding writes into a repo, what sync mode commits, and what review
+mode stores as workflow artifacts.
 
 ## The artifacts
 
@@ -16,43 +16,41 @@ The engine writes these under `.codeboarding/`:
 
 ## Decision
 
-**Commit (text, small, display-critical):**
+**Commit in sync mode:**
 - ✅ `analysis.json` — required for the extension (and later the webview) to **show the diagram instantly without regenerating** — i.e. without spending the user's API key. It's text and diffs meaningfully.
 - ✅ `health/health_report.json` — required for warnings in the extension/webview. Small text.
+- ✅ `static_analysis.pkl` + `static_analysis.sha` — required for reliable warm-start incremental sync from the committed baseline.
 
-**Do NOT commit (binary, bloat):**
-- ❌ `static_analysis.pkl` — binary, MB-scale, noisy diffs, repo bloat. It is a *rebuildable speed cache*, not display data. Keep it in **`actions/cache` keyed by the base SHA** (or a backend). On a cache miss the review action **seeds it deterministically** (LSP + clustering, no LLM calls) — the pkl is not optional for incremental: the engine refuses to run incrementally without the cluster baseline stored inside it.
-- `static_analysis.sha` — commit **only** if the pkl is kept reachable (cache/backend); on its own it's harmless but unused.
+**Upload in review mode:**
+- ✅ PR base/head `analysis.json`, head health report, rendered diagram, and metadata — stored as a GitHub Actions artifact.
 
-> **Principle:** version-control the *source-of-truth display data* (text, small); *cache* the *rebuildable speed artifacts* (binary, large). This is exactly what keeps the repo clean — the thing that bloats (`.pkl`) never enters git.
+> **Principle:** sync mode is the only git writer. Review mode never commits generated files to PR branches, so generated artifacts cannot conflict with `main` during merge.
 
 ## Where to commit — two separate workflows
 
-1. **CI/CD on `main` (the baseline keeper).** On push to `main`, regenerate and commit `analysis.json` + `health/health_report.json` to `main`. Keeps the baseline current so PRs diff against an accurate, up-to-date snapshot and the extension shows a real diagram on the default branch.
+1. **CI/CD on `main` (the baseline keeper).** On push to `main`, regenerate and commit `analysis.json`, `static_analysis.pkl`, `static_analysis.sha`, `health/health_report.json`, and rendered docs to `main`. Keeps the baseline current so PRs diff against an accurate, up-to-date snapshot and the extension shows a real diagram on the default branch.
 
-2. **The review action (PR).** **Comment-only by default** — no commits to contributors' branches (no churn, and it still works on fork PRs where the token is read-only). The PR comment leads users to the extension.
-   - *Optional later:* commit the head `analysis.json` to the PR branch so opening the extension on that PR shows the exact head diagram. Deferred — it pushes a bot commit to the contributor's branch and can't run on fork PRs.
+2. **The review action (PR).** Comment plus GitHub Actions artifact — no commits to contributors' branches (no churn, no generated-file merge conflicts, and it works on fork PRs where the token is read-only).
 
 ## Now vs. later
 
 - **Now — extension-direct.** Committing `analysis.json` + `health_report.json` on `main` means a user who installs the extension and opens the repo sees the committed diagram + warnings **instantly, with no API key**. The PR comment's CTA points straight at the extension (install / open in editor).
-- **Later — hosted webview.** The webview needs the **same** committed `analysis.json` (+ a diff + health). So committing now is **forward-compatible**: when the viewer is built, the data already exists at each commit — no migration, just a host layer that reads it.
+- **Later — hosted webview.** The webview can read durable default-branch data from committed sync artifacts and PR-specific data from the uploaded review artifact or a backend copy of that artifact.
 
 ## Warm-start tradeoff (the `.pkl`)
 
-The warm-start — and the engine's incremental path itself — needs the pkl **and** its `.sha`: the cluster baseline that drives incremental lives only inside the pkl, so a committed `analysis.json` alone forces the head run into a full (LLM) fallback. The review action therefore guarantees the pair exists for the base SHA:
+The warm-start — and the engine's incremental path itself — needs the pkl **and** its `.sha`: the cluster baseline that drives incremental lives only inside the pkl. Sync mode commits the pair alongside `analysis.json`, and review mode can still fall back to Actions cache or deterministic seeding when needed:
 
-- **No committed baseline:** the generated base analysis writes the pkl as a side effect; the artifact dir is saved in `actions/cache` keyed by base SHA / depth / engine ref.
-- **Committed baseline:** the action first requires `analysis.json.metadata.commit_hash` to equal the PR base SHA. A stale committed diagram is treated like no baseline, so the base is regenerated at the PR base commit before diffing.
-- **Committed baseline, cache miss:** the action *seeds* the pkl deterministically (`engine_adapter.py seed`: LSP indexing + the same clustering call a full run makes — **no LLM calls**), then saves it to the same cache. Seeding is fail-open: if it fails, the head run falls back to a full analysis.
+- **Committed sync baseline:** sync copies `static_analysis.pkl` + `.sha` from `.codeboarding/` into the analysis workdir before incremental analysis.
+- **No committed pkl or cache miss:** the action can seed the pkl deterministically (`engine_adapter.py seed`: LSP indexing + the same clustering call a full run makes — **no LLM calls**), then save it to `actions/cache`. Seeding is fail-open: if it fails, the head run falls back to a full analysis.
 
-Either way the head analysis is seeded from that directory and runs incrementally. This keeps the repo clean — the pkl never enters git — while the cache + seeding make incremental work from the first PR run.
+Either way the head analysis is seeded from that directory and runs incrementally when possible.
 
 ## Summary
 
 | Artifact | Commit? | Where | Why |
 |---|---|---|---|
-| `analysis.json` | ✅ | `main` (CI/CD); PR branch optional/later | diagram source; powers extension now + webview later |
-| `health_report.json` | ✅ | with `analysis.json` | warnings |
-| `static_analysis.pkl` | ❌ | `actions/cache` (or backend), key = base SHA | binary speed cache; never bloat git |
-| `static_analysis.sha` | ⚠️ optional | with the cached pkl | warm-start gate; useless without the pkl |
+| `analysis.json` | ✅ | sync commit on `main`; review artifact for PRs | diagram source |
+| `health_report.json` | ✅ | sync commit on `main`; review artifact for PRs | warnings |
+| `static_analysis.pkl` | ✅ | sync commit on `main` only | warm-start incremental baseline |
+| `static_analysis.sha` | ✅ | with `static_analysis.pkl` | warm-start gate |

--- a/docs/COMMIT_STRATEGY.md
+++ b/docs/COMMIT_STRATEGY.md
@@ -22,7 +22,7 @@ The engine writes these under `.codeboarding/`:
 - ✅ `static_analysis.pkl` + `static_analysis.sha` — required for reliable warm-start incremental sync from the committed baseline.
 
 **Upload in review mode:**
-- ✅ PR base/head `analysis.json`, head health report, rendered diagram, and metadata — stored as a GitHub Actions artifact.
+- ✅ PR-head `analysis.json` and metadata containing the PR base SHA plus the committed baseline SHA when one was found — stored as a GitHub Actions artifact.
 
 > **Principle:** sync mode is the only git writer. Review mode never commits generated files to PR branches, so generated artifacts cannot conflict with `main` during merge.
 
@@ -51,6 +51,6 @@ Either way the head analysis is seeded from that directory and runs incrementall
 | Artifact | Commit? | Where | Why |
 |---|---|---|---|
 | `analysis.json` | ✅ | sync commit on `main`; review artifact for PRs | diagram source |
-| `health_report.json` | ✅ | sync commit on `main`; review artifact for PRs | warnings |
+| `health_report.json` | ✅ | sync commit on `main`; computed in review for comments, not uploaded | warnings |
 | `static_analysis.pkl` | ✅ | sync commit on `main` only | warm-start incremental baseline |
 | `static_analysis.sha` | ✅ | with `static_analysis.pkl` | warm-start gate |

--- a/scripts/build_cta.py
+++ b/scripts/build_cta.py
@@ -3,10 +3,8 @@
 The body is a single line — "Explore this PR's architecture in your browser or
 VS Code" — that merges the hosted-webview link with the editor link(s), preceded by
 a warning banner when real health findings exist. The "browser" link (a no-install
-hosted webview) is included only when ``webview_ready`` — i.e. the head
-``analysis.json`` was committed to the PR branch and this isn't a fork PR — so the
-webview can fetch a committed analysis at the head SHA (see docs/COMMIT_STRATEGY.md);
-otherwise the line is just the editor link(s). With a click proxy (``cta_base``) the
+hosted webview) is included only when ``webview_ready`` and points at the uploaded
+GitHub Actions artifact for this PR analysis. With a click proxy (``cta_base``) the
 editor link routes through it (owner/repo/pr tracked) and deep-links into the editor
 (the proxy redirects to a ``vscode:``/``cursor:`` URL), and a separate "install the
 extension" link is appended. Without a proxy GitHub's comment sanitizer strips custom
@@ -61,14 +59,23 @@ _EDITOR_MARKETPLACE = {
 }
 
 
-def webview_url(webview_base: str, owner: str, repo: str, head_sha: str, base_sha: str) -> str | None:
+def webview_url(
+    webview_base: str,
+    owner: str,
+    repo: str,
+    head_sha: str,
+    base_sha: str,
+    *,
+    pr: str = "",
+    run_id: str = "",
+    artifact_name: str = "",
+    artifact_url: str = "",
+) -> str | None:
     """Return the hosted-webview deep-link URL for this PR's head-vs-base diff, or None.
 
-    Deep-links straight to the diff: ``?repo=owner/repo&ref=<head_sha>&compare=<base_sha>``.
-    Pinned to exact SHAs so the committed ``analysis.json`` the webview fetches matches
-    this run. For a private repo the webview itself sends the viewer through GitHub
-    sign-in and then loads the same diff. Returns None when the base/head pieces aren't
-    all present.
+    Deep-links straight to the diff. The base/head SHAs pin the code comparison;
+    the optional run/artifact fields let the webview load PR-specific analysis
+    data from the workflow artifact instead of from the PR branch.
     """
     if not (webview_base and owner and repo and head_sha):
         return None
@@ -76,6 +83,14 @@ def webview_url(webview_base: str, owner: str, repo: str, head_sha: str, base_sh
     params = {"repo": f"{owner}/{repo}", "ref": head_sha}
     if base_sha:
         params["compare"] = base_sha
+    if pr:
+        params["pr"] = pr
+    if run_id:
+        params["run_id"] = run_id
+    if artifact_name:
+        params["artifact"] = artifact_name
+    if artifact_url:
+        params["artifact_url"] = artifact_url
     return f"{base}/?{urlencode(params)}"
 
 
@@ -100,6 +115,9 @@ def build_cta(
     head_sha: str = "",
     base_sha: str = "",
     webview_ready: bool = False,
+    run_id: str = "",
+    artifact_name: str = "",
+    artifact_url: str = "",
 ) -> str:
     """Return the markdown CTA footer: a health-warning banner plus an editor link.
 
@@ -109,10 +127,8 @@ def build_cta(
     ``vscode:``/``cursor:`` schemes), and the redundant install link is dropped.
     The ⚠️ banner shows whenever ``issues > 0``.
 
-    When ``webview_ready`` (the head ``analysis.json`` was committed and this isn't a
-    fork PR) a "explore in browser" line deep-links the hosted webview to this PR's
-    head-vs-base diff. Otherwise that line is omitted (the webview couldn't fetch a
-    committed analysis at the head SHA).
+    When ``webview_ready`` a "explore in browser" line deep-links the hosted
+    webview to this PR's artifact-backed head-vs-base diff.
     """
     parts: list[str] = []
     if issues > 0:
@@ -132,14 +148,23 @@ def build_cta(
         editor_href = {e: _EDITOR_MARKETPLACE[e] for e in editors}
         extension_href = None
 
-    # One line that merges the hosted-webview "browser" link — only when
-    # ``webview_ready`` (the head analysis was committed and this isn't a fork PR) —
-    # with the editor link(s), which always render. "your" rides with the browser
-    # entry alone, so the sentence reads naturally with or without it:
+    # One line that merges the hosted-webview "browser" link with the editor
+    # link(s), which always render. "your" rides with the browser entry alone,
+    # so the sentence reads naturally with or without it:
     # "in your browser or VS Code" / "in VS Code".
     targets: list[str] = []
     if webview_ready:
-        wv = webview_url(webview_base, owner, repo, head_sha, base_sha)
+        wv = webview_url(
+            webview_base,
+            owner,
+            repo,
+            head_sha,
+            base_sha,
+            pr=pr,
+            run_id=run_id,
+            artifact_name=artifact_name,
+            artifact_url=artifact_url,
+        )
         if wv:
             targets.append(f"your [**browser**]({wv})")
     targets += [f"[**{_EDITOR_LABEL[e]}**]({editor_href[e]})" for e in editors]
@@ -164,10 +189,13 @@ def main() -> int:
     p.add_argument("--webview-base", default="", help="Hosted webview base URL (e.g. https://app.codeboarding.org)")
     p.add_argument("--head-sha", default="", help="PR head SHA the webview link pins to")
     p.add_argument("--base-sha", default="", help="PR base SHA the webview link compares against")
+    p.add_argument("--run-id", default="", help="GitHub Actions run id containing the PR analysis artifact")
+    p.add_argument("--artifact-name", default="", help="GitHub Actions artifact name containing PR analysis data")
+    p.add_argument("--artifact-url", default="", help="GitHub Actions artifact URL containing PR analysis data")
     p.add_argument(
         "--webview-ready",
         action="store_true",
-        help="Emit the webview link (head analysis.json was committed; not a fork PR)",
+        help="Emit the artifact-backed hosted webview link",
     )
     args = p.parse_args()
 
@@ -187,6 +215,9 @@ def main() -> int:
             head_sha=args.head_sha,
             base_sha=args.base_sha,
             webview_ready=args.webview_ready,
+            run_id=args.run_id,
+            artifact_name=args.artifact_name,
+            artifact_url=args.artifact_url,
         )
     )
     return 0

--- a/scripts/engine_adapter.py
+++ b/scripts/engine_adapter.py
@@ -327,8 +327,12 @@ def run_head(
     target_ref: str,
     source_sha: str,
 ) -> None:
-    """Review PR head: incremental from the PR base, full on a cache miss."""
-    _incremental_or_full(
+    """Review PR head: incremental from the PR base, full on a cache miss.
+
+    Print the selected mode explicitly so GitHub Action logs make it obvious
+    whether review used the incremental path or fell back to a full analysis.
+    """
+    mode = _incremental_or_full(
         repo_path=repo_path,
         output_dir=output_dir,
         repo_name=repo_name,
@@ -339,6 +343,7 @@ def run_head(
         source_sha=source_sha,
         log_name="cb-head.log",
     )
+    print(f"head_analysis_mode={mode}")
 
 
 def run_analyze(

--- a/scripts/engine_adapter.py
+++ b/scripts/engine_adapter.py
@@ -140,12 +140,12 @@ def _supported_depth(metadata: dict) -> int | None:
     return depth if depth in range(1, 4) else None
 
 
-def _analysis_depth_or_default(output_dir: Path, default: int = _DEFAULT_DEPTH) -> int:
+def _analysis_depth_or_default(output_dir: Path, default_depth: int = _DEFAULT_DEPTH) -> int:
     metadata = _load_metadata(output_dir / "analysis.json")
     if not isinstance(metadata, dict):
-        return default
+        return default_depth
     depth = _supported_depth(metadata)
-    return depth if depth is not None else default
+    return depth if depth is not None else default_depth
 
 
 def _metadata_commit(metadata: dict) -> str:

--- a/scripts/engine_adapter.py
+++ b/scripts/engine_adapter.py
@@ -24,11 +24,14 @@ baseline-info/analyze/render/concat. ``base`` runs a full analysis; ``seed``
 builds the SHA-tagged static-analysis pkl for a committed-analysis.json baseline
 (LSP + clustering, no LLM) so the incremental path can run; ``health`` writes
 the WARNING/CRITICAL finding count to ``--issues-out`` (never fails the run);
-``validate-base`` exits non-zero when the committed baseline cannot be reused
-for the PR base (wrong commit, or — with ``--expected-depth`` — a depth_level
-DEEPER than requested; shallower is accepted because the engine records the
-depth reached, not the depth asked); ``baseline-info`` prints the baseline's
-``commit_hash=`` (empty unless present and SHA-shaped).
+``validate-base`` exits non-zero only when the committed baseline is unreadable
+or — with ``--expected-depth`` — its depth_level is DEEPER than requested;
+shallower is accepted because the engine records the depth reached, not the
+depth asked. The baseline's metadata.commit_hash is informational in review
+mode: sync commits generated artifacts on top of the analyzed source commit, so
+review trusts the analysis.json committed at the PR base rather than
+regenerating because the metadata SHA differs. ``baseline-info`` prints the
+baseline's ``commit_hash=`` (empty unless present and SHA-shaped).
 
 ``head`` (review) and ``analyze`` (sync) are the SAME incremental-or-full
 operation via the shared ``_incremental_or_full`` helper; they differ only in
@@ -55,7 +58,6 @@ import json
 import os
 import re
 import shutil
-import subprocess
 from pathlib import Path
 
 # A committed analysis.json's commit_hash is trusted only as far as a SHA shape:
@@ -164,63 +166,15 @@ def baseline_info(analysis_path: Path) -> str:
     return commit if _SHA_RE.match(commit) else ""
 
 
-def _docs_only_baseline_drift(actual_sha: str, expected_sha: str) -> tuple[bool, str]:
-    allowed_prefixes = (".codeboarding/", "docs/development/")
-
-    def generated_only(paths: list[str]) -> tuple[bool, str]:
-        disallowed = [
-            path
-            for path in paths
-            if not path.startswith(allowed_prefixes) and path not in (".codeboarding", "docs/development")
-        ]
-        if disallowed:
-            preview = ", ".join(disallowed[:5])
-            suffix = "" if len(disallowed) <= 5 else f", and {len(disallowed) - 5} more"
-            return False, f"non-doc paths changed: {preview}{suffix}"
-        return True, "generated files only"
-
-    def git(*args: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            ["git", *args],
-            check=False,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-
-    ancestor = git("merge-base", "--is-ancestor", actual_sha, expected_sha)
-    if ancestor.returncode != 0:
-        parents = git("show", "-s", "--format=%P", expected_sha)
-        if parents.returncode == 0 and actual_sha in parents.stdout.split():
-            changed = git("diff-tree", "--no-commit-id", "--name-only", "-r", expected_sha)
-            if changed.returncode == 0:
-                paths = [line.strip() for line in changed.stdout.splitlines() if line.strip()]
-                ok, reason = generated_only(paths)
-                if ok:
-                    return True, f"PR base {expected_sha} is a generated baseline commit over {actual_sha}"
-                return False, reason
-        detail = ancestor.stderr.strip() or f"{actual_sha} is not an ancestor of {expected_sha}"
-        return False, detail
-
-    diff = git("diff", "--name-only", f"{actual_sha}..{expected_sha}")
-    if diff.returncode != 0:
-        return False, diff.stderr.strip() or f"Could not diff {actual_sha}..{expected_sha}"
-
-    paths = [line.strip() for line in diff.stdout.splitlines() if line.strip()]
-    ok, reason = generated_only(paths)
-    if not ok:
-        return False, reason
-    return True, f"only generated docs changed between {actual_sha} and {expected_sha}"
-
-
 def validate_base_analysis(
     analysis_path: Path, expected_sha: str, expected_depth: int | None = None
 ) -> tuple[bool, str]:
     """Return whether ``analysis.json`` is valid for ``expected_sha``.
 
-    The PR action can only reuse a committed baseline when the diagram's own
-    source commit matches the PR base commit, or when the PR base is a docs-bot
-    commit whose only drift from that source commit is generated docs.
+    Review mode reuses the analysis.json that is committed at the PR base. The
+    diagram's metadata.commit_hash records the source commit analyzed by sync,
+    but the sync commit itself necessarily has a newer SHA because it adds the
+    generated artifacts. Treat that metadata SHA as provenance, not freshness.
 
     When ``expected_depth`` is given, a baseline whose metadata.depth_level
     parses as an int and is DEEPER than expected is rejected (review mode
@@ -246,19 +200,13 @@ def validate_base_analysis(
         return False, "Baseline analysis metadata is missing."
 
     actual_sha = metadata.get("commit_hash")
-    if not isinstance(actual_sha, str) or not actual_sha:
-        return False, "Baseline analysis metadata.commit_hash is missing."
-
-    if actual_sha != expected_sha:
-        ok, reason = _docs_only_baseline_drift(actual_sha, expected_sha)
-        if not ok:
-            return (
-                False,
-                f"Baseline analysis was generated for {actual_sha}, expected PR base {expected_sha} ({reason}).",
-            )
-        message = f"Baseline analysis was generated for {actual_sha}; valid for PR base {expected_sha} ({reason})."
+    if isinstance(actual_sha, str) and actual_sha:
+        if actual_sha == expected_sha:
+            message = f"Baseline analysis commit matches PR base {expected_sha}."
+        else:
+            message = f"Using committed baseline at PR base {expected_sha}; analysis metadata source is {actual_sha}."
     else:
-        message = f"Baseline analysis commit matches PR base {expected_sha}."
+        message = f"Using committed baseline at PR base {expected_sha}; analysis metadata.commit_hash is missing."
 
     if expected_depth is not None:
         baseline_depth = _metadata_depth(metadata)

--- a/scripts/engine_adapter.py
+++ b/scripts/engine_adapter.py
@@ -34,8 +34,11 @@ depth reached, not the depth asked); ``baseline-info`` prints the baseline's
 operation via the shared ``_incremental_or_full`` helper; they differ only in
 where the base ref comes from (the PR base SHA vs the committed analysis.json)
 and in that ``analyze`` is baseline-aware (full when the baseline is missing,
-deeper than requested, lacks a commit_hash, or ``--force-full`` is set) and
-prints ``analysis_mode=full|incremental`` on stdout for the action to grep.
+lacks a commit_hash, or ``--force-full`` is set) and prints
+``analysis_mode=full|incremental`` on stdout for the action to grep. Once an
+analysis.json exists, its metadata.depth_level is the source of truth for
+incremental and fallback-full depth; ``--depth`` is the cold-start/force-full
+depth.
 ``render`` writes per-component markdown with root name ``overview``; ``concat``
 joins overview.md first plus the remaining *.md (sorted) into one architecture
 file.
@@ -59,6 +62,7 @@ from pathlib import Path
 # it flows into GITHUB_OUTPUT, cache keys, and git refs, so anything else must
 # be rejected before it reaches the action shell.
 _SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+_DEFAULT_DEPTH = 2
 
 # On the free hosted tier the proxy returns HTTP 402 with this message when the
 # repo owner's weekly token budget is spent. We detect it so the action can post
@@ -129,6 +133,19 @@ def _metadata_depth(metadata: dict) -> int | None:
         return None
 
 
+def _supported_depth(metadata: dict) -> int | None:
+    depth = _metadata_depth(metadata)
+    return depth if depth in range(1, 4) else None
+
+
+def _analysis_depth_or_default(output_dir: Path, default: int = _DEFAULT_DEPTH) -> int:
+    metadata = _load_metadata(output_dir / "analysis.json")
+    if not isinstance(metadata, dict):
+        return default
+    depth = _supported_depth(metadata)
+    return depth if depth is not None else default
+
+
 def _metadata_commit(metadata: dict) -> str:
     value = metadata.get("commit_hash")
     return value if isinstance(value, str) else ""
@@ -150,6 +167,18 @@ def baseline_info(analysis_path: Path) -> str:
 def _docs_only_baseline_drift(actual_sha: str, expected_sha: str) -> tuple[bool, str]:
     allowed_prefixes = (".codeboarding/", "docs/development/")
 
+    def generated_only(paths: list[str]) -> tuple[bool, str]:
+        disallowed = [
+            path
+            for path in paths
+            if not path.startswith(allowed_prefixes) and path not in (".codeboarding", "docs/development")
+        ]
+        if disallowed:
+            preview = ", ".join(disallowed[:5])
+            suffix = "" if len(disallowed) <= 5 else f", and {len(disallowed) - 5} more"
+            return False, f"non-doc paths changed: {preview}{suffix}"
+        return True, "generated files only"
+
     def git(*args: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             ["git", *args],
@@ -161,6 +190,15 @@ def _docs_only_baseline_drift(actual_sha: str, expected_sha: str) -> tuple[bool,
 
     ancestor = git("merge-base", "--is-ancestor", actual_sha, expected_sha)
     if ancestor.returncode != 0:
+        parents = git("show", "-s", "--format=%P", expected_sha)
+        if parents.returncode == 0 and actual_sha in parents.stdout.split():
+            changed = git("diff-tree", "--no-commit-id", "--name-only", "-r", expected_sha)
+            if changed.returncode == 0:
+                paths = [line.strip() for line in changed.stdout.splitlines() if line.strip()]
+                ok, reason = generated_only(paths)
+                if ok:
+                    return True, f"PR base {expected_sha} is a generated baseline commit over {actual_sha}"
+                return False, reason
         detail = ancestor.stderr.strip() or f"{actual_sha} is not an ancestor of {expected_sha}"
         return False, detail
 
@@ -169,15 +207,9 @@ def _docs_only_baseline_drift(actual_sha: str, expected_sha: str) -> tuple[bool,
         return False, diff.stderr.strip() or f"Could not diff {actual_sha}..{expected_sha}"
 
     paths = [line.strip() for line in diff.stdout.splitlines() if line.strip()]
-    disallowed = [
-        path
-        for path in paths
-        if not path.startswith(allowed_prefixes) and path not in (".codeboarding", "docs/development")
-    ]
-    if disallowed:
-        preview = ", ".join(disallowed[:5])
-        suffix = "" if len(disallowed) <= 5 else f", and {len(disallowed) - 5} more"
-        return False, f"non-doc paths changed: {preview}{suffix}"
+    ok, reason = generated_only(paths)
+    if not ok:
+        return False, reason
     return True, f"only generated docs changed between {actual_sha} and {expected_sha}"
 
 
@@ -321,14 +353,16 @@ def _incremental_or_full(
         return "incremental"
     except (IncrementalCacheMissingError, BaselineUnavailableError) as exc:
         print(f"Incremental unavailable ({exc}); running full analysis.")
-        _clear_dir(Path(output_dir))
+        out_path = Path(output_dir)
+        fallback_depth = _analysis_depth_or_default(out_path, depth)
+        _clear_dir(out_path)
         res = run_full(
             repo_name=repo_name,
             repo_path=Path(repo_path),
-            output_dir=Path(output_dir),
+            output_dir=out_path,
             run_id=run_id,
             log_path=_log_path(output_dir, log_name),
-            depth_level=depth,
+            depth_level=fallback_depth,
             source_sha=source_sha,
         )
         print(f"Analysis written: {res}")
@@ -369,13 +403,13 @@ def run_analyze(
     force_full: bool = False,
 ) -> str:
     """Sync analysis: incremental from the committed baseline, full when the
-    baseline is missing/deeper-than-requested/unparseable or ``force_full`` is
-    set. Prints ``analysis_mode=full|incremental`` on stdout — the action greps
-    that line, so it must be printed exactly once per run.
+    baseline is missing/unparseable or ``force_full`` is set. Prints
+    ``analysis_mode=full|incremental`` on stdout — the action greps that line,
+    so it must be printed exactly once per run.
     """
     out_path = Path(output_dir)
 
-    def full(reason: str) -> str:
+    def full(reason: str, analysis_depth: int) -> str:
         from codeboarding_workflows.analysis import run_full
 
         print(f"{reason}; running full analysis.")
@@ -386,7 +420,7 @@ def run_analyze(
             output_dir=out_path,
             run_id=run_id,
             log_path=_log_path(output_dir, "cb-sync.log"),
-            depth_level=depth,
+            depth_level=analysis_depth,
             source_sha=source_sha,
         )
         print(f"Analysis written: {res}")
@@ -394,32 +428,26 @@ def run_analyze(
         return "full"
 
     if force_full:
-        return full("Full analysis forced (force_full)")
+        return full("Full analysis forced (force_full)", depth)
 
     metadata = _load_metadata(out_path / "analysis.json")
     if metadata is None:
-        return full("No baseline analysis.json found")
+        return full("No baseline analysis.json found", depth)
 
-    # The engine records the depth REACHED, not the depth requested, so a
-    # shallower baseline is normal for repos that never expand (a strict !=
-    # would force a full run on every push, never converging). Only a deeper
-    # baseline proves the requested depth was lowered; honor it with a full run.
-    baseline_depth = _metadata_depth(metadata)
+    baseline_depth = _supported_depth(metadata)
     if baseline_depth is None:
-        return full("Baseline metadata.depth_level is missing")
-    if baseline_depth > depth:
-        return full(f"Baseline depth {baseline_depth} is deeper than requested depth {depth}")
+        return full("Baseline metadata.depth_level is missing", _DEFAULT_DEPTH)
 
     base_ref = _metadata_commit(metadata)
     if not base_ref:
-        return full("Baseline metadata.commit_hash is missing")
+        return full("Baseline metadata.commit_hash is missing", baseline_depth)
 
     mode = _incremental_or_full(
         repo_path=repo_path,
         output_dir=output_dir,
         repo_name=repo_name,
         run_id=run_id,
-        depth=depth,
+        depth=baseline_depth,
         base_ref=base_ref,
         target_ref=source_sha,
         source_sha=source_sha,

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -89,10 +89,23 @@ else
   BASE_DIR="$OUT/base"; HEAD_DIR="$OUT/head"
   rm -rf "$BASE_DIR" "$HEAD_DIR"; mkdir -p "$BASE_DIR" "$HEAD_DIR"
 
-  echo "== Resolving base analysis at $BASE_SHA =="
-  if git -C "$REPO" show "$BASE_SHA:.codeboarding/analysis.json" > "$BASE_DIR/analysis.json" 2>/dev/null \
-     && run_engine validate-base --analysis "$BASE_DIR/analysis.json" --expected-sha "$BASE_SHA"; then
-    echo "  using committed baseline"
+  echo "== Resolving base analysis from head history at or before $HEAD_SHA =="
+  BASELINE_SHA=""
+  while IFS= read -r candidate; do
+    if git -C "$REPO" cat-file -e "${candidate}:.codeboarding/analysis.json" 2>/dev/null; then
+      BASELINE_SHA="$candidate"
+      break
+    fi
+  done < <(git -C "$REPO" rev-list "$HEAD_SHA" -- .codeboarding/analysis.json 2>/dev/null || true)
+
+  if [ -n "$BASELINE_SHA" ] \
+     && git -C "$REPO" show "$BASELINE_SHA:.codeboarding/analysis.json" > "$BASE_DIR/analysis.json" 2>/dev/null \
+     && run_engine validate-base --analysis "$BASE_DIR/analysis.json" --expected-sha "$BASELINE_SHA"; then
+    if [ "$BASELINE_SHA" = "$HEAD_SHA" ]; then
+      echo "  using committed baseline at head"
+    else
+      echo "  using nearest committed baseline at $BASELINE_SHA from head history"
+    fi
     # Mirror action.yml: a committed analysis.json alone can't drive incremental —
     # the engine needs the base static_analysis.pkl with its cluster baseline.
     # Seed it deterministically (LSP + clustering, no LLM); fail-open on error.
@@ -100,8 +113,8 @@ else
     git -C "$REPO" worktree remove --force "$BASE_SRC" 2>/dev/null || true
     git -C "$REPO" worktree prune
     rm -rf "$BASE_SRC"
-    git -C "$REPO" worktree add --detach "$BASE_SRC" "$BASE_SHA" >/dev/null
-    if run_engine seed --repo "$BASE_SRC" --out "$BASE_DIR" --source-sha "$BASE_SHA"; then
+    git -C "$REPO" worktree add --detach "$BASE_SRC" "$BASELINE_SHA" >/dev/null
+    if run_engine seed --repo "$BASE_SRC" --out "$BASE_DIR" --source-sha "$BASELINE_SHA"; then
       echo "  seeded static-analysis baseline (no LLM)"
     else
       rm -f "$BASE_DIR/static_analysis.pkl" "$BASE_DIR/static_analysis.sha"
@@ -135,7 +148,7 @@ else
     --name "$(basename "$REPO")" \
     --run-id local-head \
     --depth "$DEPTH" \
-    --base-ref "$BASE_SHA" \
+    --base-ref "${BASELINE_SHA:-$BASE_SHA}" \
     --target-ref "$HEAD_SHA" \
     --source-sha "$HEAD_SHA"
   [ -f "$HEAD_DIR/analysis.json" ] || { echo "Head analysis ran but analysis.json is missing." >&2; exit 1; }

--- a/tests/test_build_cta.py
+++ b/tests/test_build_cta.py
@@ -92,6 +92,23 @@ class TestWebviewUrl(unittest.TestCase):
         self.assertIn("ref=headsha", url)
         self.assertNotIn("compare=", url)
 
+    def test_url_includes_artifact_lookup_params(self):
+        url = bc.webview_url(
+            self.WV,
+            "o",
+            "r",
+            "headsha",
+            "basesha",
+            pr="9",
+            run_id="123",
+            artifact_name="codeboarding-pr-9-headsha",
+            artifact_url="https://github.com/o/r/actions/runs/123/artifacts/456",
+        )
+        self.assertIn("pr=9", url)
+        self.assertIn("run_id=123", url)
+        self.assertIn("artifact=codeboarding-pr-9-headsha", url)
+        self.assertIn("artifact_url=https%3A%2F%2Fgithub.com%2Fo%2Fr%2Factions%2Fruns%2F123%2Fartifacts%2F456", url)
+
     def test_url_none_without_head_sha_or_base(self):
         self.assertIsNone(bc.webview_url(self.WV, "o", "r", "", "basesha"))
         self.assertIsNone(bc.webview_url("", "o", "r", "headsha", "basesha"))
@@ -116,7 +133,7 @@ class TestWebviewUrl(unittest.TestCase):
         self.assertIn("VS Code", out)  # editor merged into the same line
 
     def test_cta_omits_browser_link_when_not_ready(self):
-        # Fork PR / head analysis not committed -> webview can't fetch at head SHA.
+        # No uploaded analysis artifact -> webview can't fetch PR-specific data.
         out = bc.build_cta(
             "",
             "Org",

--- a/tests/test_engine_adapter.py
+++ b/tests/test_engine_adapter.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import types
 import unittest
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
@@ -159,11 +159,14 @@ class TestAnalysis(_Base):
     def test_head_uses_incremental(self):
         ri, rf = _Rec(), _Rec()
         self._install(run_full=rf, run_incremental=ri)
-        engine_adapter.run_head("/repo", "/out", "r", "rid", 1, "base", "head", "head")
+        buf = StringIO()
+        with redirect_stdout(buf):
+            engine_adapter.run_head("/repo", "/out", "r", "rid", 1, "base", "head", "head")
         self.assertEqual(len(ri.calls), 1)
         self.assertEqual(len(rf.calls), 0)  # no fallback
         self.assertEqual(ri.calls[0]["base_ref"], "base")
         self.assertEqual(ri.calls[0]["target_ref"], "head")
+        self.assertIn("head_analysis_mode=incremental", buf.getvalue())
 
     def test_head_falls_back_to_full_on_cache_miss(self):
         analysis, IncMiss, _ = self._install()  # install once so the exception class identity matches
@@ -174,11 +177,14 @@ class TestAnalysis(_Base):
         (Path(out) / "stale.json").write_text("{}")  # must be wiped before the full run
         (Path(out) / "health").mkdir()
         (Path(out) / "health" / "stale.json").write_text("{}")
-        engine_adapter.run_head("/repo", out, "r", "rid", 3, "base", "head", "head")
+        buf = StringIO()
+        with redirect_stdout(buf):
+            engine_adapter.run_head("/repo", out, "r", "rid", 3, "base", "head", "head")
         self.assertEqual(len(rf.calls), 1)  # fell back to full
         self.assertEqual(rf.calls[0]["depth_level"], 3)
         self.assertFalse((Path(out) / "stale.json").exists())  # head dir wiped before full
         self.assertFalse((Path(out) / "health").exists())  # nested stale artifacts wiped too
+        self.assertIn("head_analysis_mode=full", buf.getvalue())
 
     def test_head_falls_back_to_full_on_baseline_unavailable(self):
         analysis, _, BaseUnavail = self._install()  # the other warm-start failure must also fall back

--- a/tests/test_engine_adapter.py
+++ b/tests/test_engine_adapter.py
@@ -200,14 +200,14 @@ class TestValidateBase(_Base):
             self.assertTrue(ok)
             self.assertIn("matches", message)
 
-    def test_validate_base_rejects_mismatched_commit(self):
+    def test_validate_base_accepts_mismatched_commit(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "analysis.json"
             path.write_text(json.dumps({"metadata": {"commit_hash": "old"}}), encoding="utf-8")
 
             ok, message = engine_adapter.validate_base_analysis(path, "new")
 
-            self.assertFalse(ok)
+            self.assertTrue(ok)
             self.assertIn("old", message)
             self.assertIn("new", message)
 
@@ -243,9 +243,9 @@ class TestValidateBase(_Base):
                 os.chdir(cwd)
 
             self.assertTrue(ok)
-            self.assertIn("valid for PR base", message)
+            self.assertIn("Using committed baseline", message)
 
-    def test_validate_base_rejects_code_drift(self):
+    def test_validate_base_accepts_committed_baseline_even_after_code_drift(self):
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp) / "repo"
             repo.mkdir()
@@ -271,8 +271,8 @@ class TestValidateBase(_Base):
             finally:
                 os.chdir(cwd)
 
-            self.assertFalse(ok)
-            self.assertIn("app.py", message)
+            self.assertTrue(ok)
+            self.assertIn("Using committed baseline", message)
 
     def _git(self, repo, *args):
         return subprocess.run(
@@ -284,14 +284,14 @@ class TestValidateBase(_Base):
             stderr=subprocess.PIPE,
         )
 
-    def test_validate_base_rejects_missing_commit(self):
+    def test_validate_base_accepts_missing_commit(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "analysis.json"
             path.write_text(json.dumps({"metadata": {}}), encoding="utf-8")
 
             ok, message = engine_adapter.validate_base_analysis(path, "abc123")
 
-            self.assertFalse(ok)
+            self.assertTrue(ok)
             self.assertIn("commit_hash", message)
 
     def test_main_validate_base_exit_codes(self):
@@ -305,7 +305,7 @@ class TestValidateBase(_Base):
             )
             self.assertEqual(
                 engine_adapter.main(["validate-base", "--analysis", str(path), "--expected-sha", "def456"]),
-                1,
+                0,
             )
 
     def test_validate_base_accepts_matching_depth(self):

--- a/tests/test_sync_subcommands.py
+++ b/tests/test_sync_subcommands.py
@@ -118,7 +118,7 @@ class TestAnalyze(_Base):
         self.assertEqual(kwargs["target_ref"], "head123")
         self.assertEqual(kwargs["source_sha"], "head123")
 
-    def test_deeper_baseline_clears_out_dir_and_runs_full(self):
+    def test_deeper_baseline_still_runs_incremental(self):
         rf, ri = _Rec(), _Rec()
         self._install(run_full=rf, run_incremental=ri)
         out = Path(tempfile.mkdtemp())
@@ -129,11 +129,11 @@ class TestAnalyze(_Base):
 
         mode = engine_adapter.run_analyze("/repo", str(out), "myrepo", "rid", "head123", 2)
 
-        self.assertEqual(mode, "full")
-        self.assertEqual(len(rf.calls), 1)
-        self.assertEqual(len(ri.calls), 0)
-        self.assertFalse((out / "stale.json").exists())
-        self.assertFalse((out / "health").exists())
+        self.assertEqual(mode, "incremental")
+        self.assertEqual(len(rf.calls), 0)
+        self.assertEqual(len(ri.calls), 1)
+        self.assertTrue((out / "stale.json").exists())
+        self.assertTrue((out / "health").exists())
 
     def test_shallower_baseline_runs_incremental(self):
         # The engine records the depth REACHED, not requested: a depth-2 push on
@@ -150,7 +150,7 @@ class TestAnalyze(_Base):
         self.assertEqual(len(rf.calls), 0)
         self.assertEqual(len(ri.calls), 1)
 
-    def test_missing_depth_in_baseline_runs_full(self):
+    def test_missing_depth_in_baseline_runs_full_at_default_depth(self):
         rf, ri = _Rec(), _Rec()
         self._install(run_full=rf, run_incremental=ri)
         out = Path(tempfile.mkdtemp())
@@ -158,23 +158,25 @@ class TestAnalyze(_Base):
             json.dumps({"metadata": {"commit_hash": "metadata-base"}}), encoding="utf-8"
         )
 
-        mode = engine_adapter.run_analyze("/repo", str(out), "myrepo", "rid", "head123", 2)
+        mode = engine_adapter.run_analyze("/repo", str(out), "myrepo", "rid", "head123", 3)
 
         self.assertEqual(mode, "full")
         self.assertEqual(len(rf.calls), 1)
         self.assertEqual(len(ri.calls), 0)
+        self.assertEqual(rf.calls[0][1]["depth_level"], 2)
 
-    def test_missing_commit_in_baseline_runs_full(self):
+    def test_missing_commit_in_baseline_runs_full_at_baseline_depth(self):
         rf, ri = _Rec(), _Rec()
         self._install(run_full=rf, run_incremental=ri)
         out = Path(tempfile.mkdtemp())
-        out.joinpath("analysis.json").write_text(json.dumps({"metadata": {"depth_level": 2}}), encoding="utf-8")
+        out.joinpath("analysis.json").write_text(json.dumps({"metadata": {"depth_level": 3}}), encoding="utf-8")
 
-        mode = engine_adapter.run_analyze("/repo", str(out), "myrepo", "rid", "head123", 2)
+        mode = engine_adapter.run_analyze("/repo", str(out), "myrepo", "rid", "head123", 1)
 
         self.assertEqual(mode, "full")
         self.assertEqual(len(rf.calls), 1)
         self.assertEqual(len(ri.calls), 0)
+        self.assertEqual(rf.calls[0][1]["depth_level"], 3)
 
     def test_falls_back_to_full_on_cache_miss(self):
         analysis, IncMiss, _ = self._install()
@@ -185,10 +187,11 @@ class TestAnalyze(_Base):
         _write_analysis(out, commit="metadata-base", depth=3)
         (out / "stale.json").write_text("{}", encoding="utf-8")
 
-        mode = engine_adapter.run_analyze("/repo", str(out), "myrepo", "rid", "head123", 3)
+        mode = engine_adapter.run_analyze("/repo", str(out), "myrepo", "rid", "head123", 1)
 
         self.assertEqual(mode, "full")
         self.assertEqual(len(rf.calls), 1)
+        self.assertEqual(rf.calls[0][1]["depth_level"], 3)
         self.assertFalse((out / "stale.json").exists())
 
     def test_falls_back_to_full_on_baseline_unavailable(self):
@@ -199,10 +202,11 @@ class TestAnalyze(_Base):
         out = tempfile.mkdtemp()
         _write_analysis(out, commit="metadata-base", depth=2)
 
-        mode = engine_adapter.run_analyze("/repo", out, "myrepo", "rid", "head123", 2)
+        mode = engine_adapter.run_analyze("/repo", out, "myrepo", "rid", "head123", 1)
 
         self.assertEqual(mode, "full")
         self.assertEqual(len(rf.calls), 1)
+        self.assertEqual(rf.calls[0][1]["depth_level"], 2)
 
     def _markers(self, buf):
         return [line for line in buf.getvalue().splitlines() if line.startswith("analysis_mode=")]


### PR DESCRIPTION
## What

When `depth_level` is empty (the new default), the action reads `metadata.depth_level` from the committed `.codeboarding/analysis.json`:

- **Sync mode**: from the working-tree checkout
- **Review mode**: from the PR base SHA via `git show`

Falls back to **2** when no baseline exists or the field is missing/unparseable. An explicit `depth_level` input always overrides auto-detection.

## Why

Consumers currently hardcode `depth_level: '2'` in their sync workflows. If the committed baseline was generated at a different depth, this mismatch either forces an unnecessary full regeneration or silently uses the wrong depth. Auto-detection eliminates this — the workflow stays in sync with the baseline automatically.

## Changes

- `action.yml`: input default changed from `'2'` to `''` (auto)
- New `Resolve analysis depth` step after checkout, before analysis
- All 12 downstream references (cache keys, env vars, validate-base) now use `steps.resolve_depth.outputs.depth`
- Guard validation updated to accept empty