### PR TITLE
fix: set up analysis runtimes inside action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -381,6 +381,22 @@ runs:
           <sub>codeboarding-action · run ${{ github.run_id }}</sub>
         GITHUB_TOKEN: ${{ inputs.github_token }}
 
+    - name: Setup Java for JDTLS
+      if: steps.guard.outputs.skip != 'true'
+      uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: '21'
+
+    - name: Setup .NET SDKs for C# LSP
+      if: steps.guard.outputs.skip != 'true'
+      uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: |
+          8.0.x
+          9.0.x
+          10.0.x
+
     - name: Checkout CodeBoarding engine
       if: steps.guard.outputs.skip != 'true'
       uses: actions/checkout@v4


### PR DESCRIPTION
## Summary\n- install Java 21 inside the composite action for JDTLS\n- install .NET SDKs 8/9/10 inside the composite action for C# LSP/static analysis\n- keep setup gated by the action guard so skipped review/sync runs avoid the extra setup\n\n## Validation\n- ruby -e 'require "yaml"; YAML.load_file("action.yml")'\n- bash -n scripts/run_local.sh\n- python3 -m unittest tests.test_engine_adapter tests.test_sync_subcommands tests.test_build_cta -v\n- git diff --check