### PR TITLE
Add CodeBoarding architecture analysis

### DIFF
--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -1,23 +1,11 @@
-# Dogfood sync mode: keep THIS repo's committed architecture baseline
-# (.codeboarding/analysis.json + rendered docs) current on every push to main,
-# so the PR review workflow always diffs against an up-to-date baseline.
-#
-# This is the ONLY baseline writer for this repo. The manual "rebuild from
-# scratch" path (previously a separate refresh-baseline.yml) is now the
-# workflow_dispatch + force_full input below, which runs the same tested action
-# instead of a hand-rolled copy of its pipeline.
-
 name: CodeBoarding sync
 
 on:
   push:
-    branches: [main]
+    branches: ['main']
     # Loop guard: don't re-trigger on the files this workflow itself commits.
-    # Deliberately NOT '.codeboarding/**': that would also swallow pushes that
-    # only edit the user-authored .codeboarding/.codeboardingignore, which
-    # changes analysis scope and should regenerate the baseline. The action also
-    # skips re-analyzing its own bot commit as a backstop; the bot commit uses no
-    # [skip ci] (that would leak through squash-merges and skip real merges).
+    # Listed explicitly (not '.codeboarding/**') so editing your own
+    # .codeboarding/.codeboardingignore still regenerates the baseline.
     paths-ignore:
       - '.codeboarding/*.md'
       - '.codeboarding/analysis.json'
@@ -33,12 +21,12 @@ on:
         default: false
 
 permissions:
-  contents: write   # commit the generated baseline + docs to main
+  contents: write   # commit the generated baseline + docs to the branch
+  id-token: write   # mint a GitHub OIDC token for the free hosted tier (omit if you set a key/license)
 
 concurrency:
-  # Serialize this workflow against itself: a push landing while a manual
-  # dispatch is mid-run must not produce two concurrent commits to main.
-  group: codeboarding-baseline-writers
+  # Serialize against itself so a push landing mid-run can't make two commits.
+  group: codeboarding-sync
   cancel-in-progress: false
 
 jobs:
@@ -46,13 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      # Dogfood: run the action from the checked-out repo (uses: ./) so pushes to
-      # main exercise the action code on main, not the last published release.
-      # The action reads its scripts via github.action_path and checks the engine
-      # and target repo into subdirectories, so this local checkout is untouched.
-      - uses: actions/checkout@v4
-      - uses: ./
+      - uses: CodeBoarding/CodeBoarding-action@v1
         with:
           mode: sync
           force_full: ${{ inputs.force_full || false }}
-          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -2,102 +2,31 @@ name: CodeBoarding review
 
 on:
   pull_request:
-    # Generate once, when the PR becomes reviewable, not on every push, so we
-    # don't spend an LLM job per commit. Add `synchronize` to re-run on each
-    # push, or refresh anytime with /codeboarding. 'closed' only cancels an
-    # in-flight review (see concurrency), it doesn't start one.
     types: [opened, reopened, ready_for_review, closed]
   issue_comment:
     types: [created]
 
-permissions:
-  # write: the action commits the generated .codeboarding/analysis.json back to the
-  # PR branch so the webview can open this PR's diff at the head SHA (same-repo PRs).
-  contents: write
-  pull-requests: write
-  issues: write
+# No workflow-level permissions: each job requests only what it needs (least
+# privilege), so the default token starts with none.
+permissions: {}
 
 concurrency:
   group: codeboarding-${{ github.event.pull_request.number || github.event.issue.number }}
-  # Cancel only when the PR closes — bot comments (issue_comment) and re-triggers
-  # must not cancel a running review; they queue behind it instead.
   cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
 
 jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read        # check out the repo + read the committed baseline (no writes in review mode)
+      pull-requests: write  # post the architecture-diff PR comment
+      issues: write         # the /codeboarding issue_comment trigger + comment API
+      id-token: write       # mint a GitHub OIDC token for the free hosted tier (write is the only level for id-token)
     if: >
       (github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
        startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
-      # Dogfood: run the action from the checked-out repo (uses: ./) so each PR
-      # exercises the action code under review, not the last published release.
-      # The action reads its scripts via github.action_path and checks the engine
-      # and target repo into subdirectories, so this local checkout is untouched.
-      - uses: actions/checkout@v4
-      - name: Detect CodeBoarding GitHub App credentials
-        id: codeboarding-app-config
-        shell: bash
-        env:
-          CLIENT_ID: ${{ vars.CODEBOARDING_APP_CLIENT_ID }}
-          APP_ID: ${{ vars.CODEBOARDING_APP_ID }}
-          PRIVATE_KEY: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
-        run: |
-          client_id="${CLIENT_ID:-}"
-          app_id="${APP_ID:-}"
-
-          # GitHub App client IDs start with "Iv". If that value was stored in
-          # CODEBOARDING_APP_ID, use it as a client ID to avoid the deprecated
-          # app-id input path.
-          if [ -z "$client_id" ] && [ "${app_id#Iv}" != "$app_id" ]; then
-            client_id="$app_id"
-            app_id=""
-          fi
-
-          has_private_key=false
-          private_key_valid=false
-          if [ -n "$PRIVATE_KEY" ]; then
-            has_private_key=true
-            if printf '%s' "$PRIVATE_KEY" | openssl pkey -noout >/dev/null 2>&1; then
-              private_key_valid=true
-            else
-              echo "::warning::CODEBOARDING_APP_PRIVATE_KEY is not a valid PEM private key, so CodeBoarding will fall back to github-actions[bot]."
-              if printf '%b' "$PRIVATE_KEY" | openssl pkey -noout >/dev/null 2>&1; then
-                printf '%s\n' "::warning::CODEBOARDING_APP_PRIVATE_KEY looks like it contains literal \\n escapes. Store the downloaded PEM as multi-line secret text instead."
-              fi
-            fi
-          fi
-
-          {
-            [ -n "$client_id" ] && echo "has_client_id=true" || echo "has_client_id=false"
-            [ -n "$app_id" ] && echo "has_app_id=true" || echo "has_app_id=false"
-            echo "client_id=$client_id"
-            echo "has_private_key=$has_private_key"
-            echo "private_key_valid=$private_key_valid"
-          } >> "$GITHUB_OUTPUT"
-      - uses: actions/create-github-app-token@v3
-        id: codeboarding-app-token-client
-        if: steps.codeboarding-app-config.outputs.has_client_id == 'true' && steps.codeboarding-app-config.outputs.private_key_valid == 'true'
-        continue-on-error: true
-        with:
-          client-id: ${{ steps.codeboarding-app-config.outputs.client_id }}
-          private-key: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
-      - uses: actions/create-github-app-token@v3
-        id: codeboarding-app-token-app
-        if: steps.codeboarding-app-config.outputs.has_client_id != 'true' && steps.codeboarding-app-config.outputs.has_app_id == 'true' && steps.codeboarding-app-config.outputs.private_key_valid == 'true'
-        continue-on-error: true
-        with:
-          app-id: ${{ vars.CODEBOARDING_APP_ID }}
-          private-key: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
-      - name: Warn when CodeBoarding App token is unavailable
-        if: steps.codeboarding-app-token-client.outputs.token == '' && steps.codeboarding-app-token-app.outputs.token == ''
-        shell: bash
-        run: |
-          echo "::warning::CodeBoarding GitHub App token is unavailable; falling back to github-actions[bot]. Check CODEBOARDING_APP_PRIVATE_KEY formatting if app credentials are configured."
-      - uses: ./
-        with:
-          github_token: ${{ steps.codeboarding-app-token-client.outputs.token || steps.codeboarding-app-token-app.outputs.token || github.token }}
-          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+      - uses: CodeBoarding/CodeBoarding-action@v1


### PR DESCRIPTION
This PR adds the [CodeBoarding](https://codeboarding.org) GitHub Action via **two workflows**:

- **`codeboarding-sync.yml`** — on every push to your default branch, commits
  `.codeboarding/analysis.json` (your architecture baseline + readable docs). This is
  what the [CodeBoarding viewer](https://app.codeboarding.org) opens.
- **`codeboarding.yml`** — on every pull request, posts an architecture-diff comment and
  uploads that PR’s analysis as a build artifact for the viewer’s PR diff.

Both are needed: sync produces the baseline; review diffs against it.

### Works out of the box
Just merge it — the Action runs on the **free tier**, with no extra setup. The
`id-token: write` permission lets it identify your repo to CodeBoarding’s hosted LLM,
metered per account against a weekly limit.

### Want more, or unmetered, usage?
Add an LLM provider key — OpenRouter (`OPENROUTER_API_KEY`), Anthropic, OpenAI, Google,
AWS Bedrock, etc. — or a `CODEBOARDING_LICENSE`, as a repository secret under
**Settings → Secrets and variables → Actions**, then pass it to the action via `llm_api_key`
(+ `llm_provider`) or `license_key`. See the
[provider list](https://github.com/CodeBoarding/CodeBoarding-action#more-usage). Optional —
the free tier needs nothing.

— opened for you by CodeBoarding