### PR TITLE
fix: install CodeBoarding engine from PyPI

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -37,7 +37,18 @@ jobs:
       # exercises the action code under review, not the last published release.
       # The action reads its scripts via github.action_path and checks the engine
       # and target repo into subdirectories, so this local checkout is untouched.
+      #
+      # On issue_comment events, checkout's default ref is the repo's DEFAULT
+      # BRANCH (the event isn't tied to a PR), so `uses: ./` would run main's
+      # action code, not this PR's — /codeboarding would silently test the wrong
+      # version. Check out the PR head explicitly for that event so the comment
+      # path dogfoods the PR under review too. pull_request events keep checkout's
+      # default (the PR merge ref), which already points at the PR. On-demand runs
+      # are restricted to same-repo PRs, so refs/pull/<n>/head resolves in this
+      # repo (no fork-repo override needed).
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
       - name: Detect CodeBoarding GitHub App credentials
         id: codeboarding-app-config
         shell: bash

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Review mode does not need `contents: write`: PR-specific generated files are sto
 | `mode` | both | `review` | `review` posts the PR architecture-diff comment; `sync` analyzes on push and commits the architecture (`analysis.json` + rendered docs) to `target_branch`, keeping it versioned and current. |
 | `github_token` | both | `${{ github.token }}` | Token for GitHub API calls; in review mode it posts or updates the PR comment. |
 | `push_token` | sync | `${{ github.token }}` | Token used for sync-mode pushes to `target_branch`. The workflow token can push when the workflow grants `permissions: contents: write`. Separate from `github_token` so commenting can use a GitHub App token while the push uses the workflow token. |
-| `engine_ref` | both | `v0.12.1` | CodeBoarding engine ref. Pin for reproducibility. |
+| `codeboarding_version` | both | `0.12.2` | CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility. |
 | `depth_level` | both | empty (`2` for cold starts) | Analysis depth, 1 to 3, used for first analysis and `force_full` rebuilds. Once `.codeboarding/analysis.json` exists, its `metadata.depth_level` is the source of truth for incremental analysis and fallback-full recovery. |
 | `render_depth` | review | `1` | Display depth for the PR diagram. Keep `1` for a clean top-level view. |
 | `diagram_direction` | review | `LR` | Mermaid direction: `LR`, `TD`, `TB`, `RL`, or `BT`. |
@@ -298,7 +298,7 @@ Outputs of the mode that did not run are empty strings.
 
 ## Notes
 
-- No checkout step is required in your workflow. This action checks out the target (the PR in review mode, the pushed commit in sync mode) and the CodeBoarding engine internally.
+- No checkout step is required in your workflow. This action checks out the target (the PR in review mode, the pushed commit in sync mode) and installs the CodeBoarding engine from PyPI internally.
 - GitHub withholds secrets from fork PRs on `pull_request`, so fork runs fail early if an LLM key is unavailable.
 - Do not use `pull_request_target` for this action. It can expose secrets to PR-head code.
 - GitHub renders Mermaid in strict mode, so node click-through links are not supported in the PR diagram.
@@ -315,8 +315,9 @@ Full local pipeline:
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-...
-scripts/run_local.sh --repo /path/to/repo --base <base-ref> --head <head-ref> \
-  --engine /path/to/CodeBoarding
+python -m pip install codeboarding==0.12.2
+codeboarding-setup --auto-install-npm
+scripts/run_local.sh --repo /path/to/repo --base <base-ref> --head <head-ref>
 ```
 
 Useful flags:

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Review mode does not need `contents: write`: PR-specific generated files are sto
 | `mode` | both | `review` | `review` posts the PR architecture-diff comment; `sync` analyzes on push and commits the architecture (`analysis.json` + rendered docs) to `target_branch`, keeping it versioned and current. |
 | `github_token` | both | `${{ github.token }}` | Token for GitHub API calls; in review mode it posts or updates the PR comment. |
 | `push_token` | sync | `${{ github.token }}` | Token used for sync-mode pushes to `target_branch`. The workflow token can push when the workflow grants `permissions: contents: write`. Separate from `github_token` so commenting can use a GitHub App token while the push uses the workflow token. |
-| `codeboarding_version` | both | `0.12.2` | CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility. |
+| `codeboarding_version` | both | `0.12.3` | CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility. |
 | `depth_level` | both | empty (`2` for cold starts) | Analysis depth, 1 to 3, used for first analysis and `force_full` rebuilds. Once `.codeboarding/analysis.json` exists, its `metadata.depth_level` is the source of truth for incremental analysis and fallback-full recovery. |
 | `render_depth` | review | `1` | Display depth for the PR diagram. Keep `1` for a clean top-level view. |
 | `diagram_direction` | review | `LR` | Mermaid direction: `LR`, `TD`, `TB`, `RL`, or `BT`. |
@@ -315,7 +315,7 @@ Full local pipeline:
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-...
-python -m pip install codeboarding==0.12.2
+python -m pip install codeboarding==0.12.3
 codeboarding-setup --auto-install-npm
 scripts/run_local.sh --repo /path/to/repo --base <base-ref> --head <head-ref>
 ```

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
   codeboarding_version:
     description: 'CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility; set to a newer released version to opt into newer engine releases.'
     required: false
-    default: '0.12.2'
+    default: '0.12.3'
   depth_level:
     description: 'Analysis depth (1-3) for cold-start or force_full rebuilds. Once .codeboarding/analysis.json exists, its metadata.depth_level is the source of truth for incremental analysis and fallback-full recovery. Empty (default): 2 for cold starts.'
     required: false
@@ -487,11 +487,15 @@ runs:
         echo "depth=$DEPTH" >> "$GITHUB_OUTPUT"
         echo "Using default cold-start depth_level=$DEPTH."
 
-    - name: Set up Python 3.13
+    - name: Set up Python 3.12
       if: steps.guard.outputs.skip != 'true'
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        # 3.12, not 3.13: the codeboarding package's transitive dep
+        # langchain-cerebras (>=0.8) is published only for >=3.11,<3.13, so a 3.13
+        # runner can't resolve the engine install. The engine itself supports
+        # <3.14, so bump this back to 3.13 once langchain-cerebras ships a 3.13 wheel.
+        python-version: '3.12'
 
     - name: Set up Node.js 20
       if: steps.guard.outputs.skip != 'true'

--- a/action.yml
+++ b/action.yml
@@ -31,10 +31,10 @@ inputs:
     description: 'Token used for sync-mode git pushes to target_branch. Defaults to the workflow github.token, which can push when the calling workflow grants "permissions: contents: write". Kept separate from github_token so commenting can use a GitHub App token while the push uses the workflow token (whose write access the consumer controls).'
     required: false
     default: ${{ github.token }}
-  engine_ref:
-    description: 'Git ref (tag/branch/SHA) of CodeBoarding/CodeBoarding used as the analysis engine. Pinned to a release for reproducibility; override to track a newer ref.'
+  codeboarding_version:
+    description: 'CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility; set to a newer released version to opt into newer engine releases.'
     required: false
-    default: 'v0.12.1'
+    default: '0.12.2'
   depth_level:
     description: 'Analysis depth (1-3) for cold-start or force_full rebuilds. Once .codeboarding/analysis.json exists, its metadata.depth_level is the source of truth for incremental analysis and fallback-full recovery. Empty (default): 2 for cold starts.'
     required: false
@@ -142,7 +142,7 @@ runs:
   # interleave only because they share the LLM-key lifecycle, NOT because they
   # are unrelated:
   #   1. GUARD            — resolve mode + event eligibility + SHAs (one source of truth)
-  #   2. SHARED SETUP     — checkout engine + target, Python/Node/uv, caches, LLM-key prep
+  #   2. SHARED SETUP     — checkout target, Python/Node/uv, install CodeBoarding, caches, LLM-key prep
   #   3. ANALYSIS (key live) — review: base/seed/head/health ; sync: seed/analyze
   #   4. Drop LLM key, then OUTPUT (no key) — review: diff→artifact→comment ; sync: render→commit
   # The binding between the modes is the committed .codeboarding/analysis.json
@@ -425,15 +425,6 @@ runs:
           9.0.x
           10.0.x
 
-    - name: Checkout CodeBoarding engine
-      if: steps.guard.outputs.skip != 'true'
-      uses: actions/checkout@v4
-      with:
-        repository: CodeBoarding/CodeBoarding
-        ref: ${{ inputs.engine_ref }}
-        path: codeboarding-engine
-        persist-credentials: false
-
     # Review mode: the PR head repo at the head SHA. Sync mode: this repo at the
     # pushed/selected SHA. Always credential-free — sync pushes authenticate
     # explicitly via push_token.
@@ -508,36 +499,36 @@ runs:
       with:
         node-version: '20'
 
-    - name: Install uv
-      if: steps.guard.outputs.skip != 'true'
-      uses: astral-sh/setup-uv@v4
-      with:
-        enable-cache: true   # cache ~/.cache/uv (wheels/builds) for fast cold installs
-
     - name: Cache LSP servers
       if: steps.guard.outputs.skip != 'true'
       uses: actions/cache@v4
       with:
         path: |
-          codeboarding-engine/static_analyzer/servers/node_modules
-          codeboarding-engine/static_analyzer/servers/bin
-        key: cb-lsp-${{ runner.os }}-v1
+          ~/.codeboarding/servers
+        key: cb-lsp-${{ runner.os }}-${{ inputs.codeboarding_version }}-v1
         restore-keys: |
           cb-lsp-${{ runner.os }}-
 
-    - name: Install Python dependencies
+    - name: Install CodeBoarding package
       if: steps.guard.outputs.skip != 'true'
       shell: bash
-      working-directory: codeboarding-engine
+      env:
+        CODEBOARDING_VERSION: ${{ inputs.codeboarding_version }}
       run: |
-        uv pip install -e .
+        set -euo pipefail
+        SPEC="$CODEBOARDING_VERSION"
+        case "$SPEC" in
+          '' ) SPEC='' ;;
+          [0-9]* ) SPEC="==$SPEC" ;;
+        esac
+        python -m pip install --upgrade pip
+        python -m pip install "codeboarding${SPEC}"
 
     - name: Install LSP servers
       if: steps.guard.outputs.skip != 'true'
       shell: bash
-      working-directory: codeboarding-engine
       run: |
-        uv run python install.py --auto-install-npm
+        codeboarding-setup --auto-install-npm
 
     - name: Prepare & verify LLM key
       if: steps.guard.outputs.skip != 'true'
@@ -784,7 +775,7 @@ runs:
         # inputs. So a free-tier run (oidc, forced Gemini) and a BYO OpenRouter-key
         # run with no model pinned would share a key yet produce different base
         # analyses; the mode discriminator keeps them from reusing each other's cache.
-        key: cb-base-v2-${{ runner.os }}-${{ steps.base.outputs.baseline_sha }}-d${{ steps.resolve_depth.outputs.depth }}-${{ inputs.engine_ref }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
+        key: cb-base-v2-${{ runner.os }}-${{ steps.base.outputs.baseline_sha }}-d${{ steps.resolve_depth.outputs.depth }}-${{ inputs.codeboarding_version }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
 
     - name: Reassert committed base analysis after cache restore
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review' && steps.base.outputs.committed == 'true'
@@ -818,10 +809,7 @@ runs:
       id: seedbase
       continue-on-error: true
       shell: bash
-      working-directory: codeboarding-engine
       env:
-        STATIC_ANALYSIS_CONFIG: ${{ github.workspace }}/codeboarding-engine/static_analysis_config.yml
-        PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
         CACHING_DOCUMENTATION: 'false'
         ENABLE_MONITORING: 'false'
         ACTION_PATH: ${{ github.action_path }}
@@ -836,7 +824,7 @@ runs:
         git -C "$TARGET" worktree prune
         rm -rf "$BASE_SRC"
         git -C "$TARGET" worktree add --detach "$BASE_SRC" "$BASELINE_SHA"
-        if uv run python "$ACTION_PATH/scripts/engine_adapter.py" seed \
+        if python "$ACTION_PATH/scripts/engine_adapter.py" seed \
              --repo "$BASE_SRC" \
              --out "$BASE_DIR" \
              --source-sha "$BASELINE_SHA" \
@@ -855,10 +843,7 @@ runs:
     - name: Generate base analysis (no committed baseline)
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review' && steps.base.outputs.empty_base != 'true' && steps.base.outputs.committed == 'false' && steps.basecache.outputs.cache-hit != 'true'
       shell: bash
-      working-directory: codeboarding-engine
       env:
-        STATIC_ANALYSIS_CONFIG: ${{ github.workspace }}/codeboarding-engine/static_analysis_config.yml
-        PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
         DIAGRAM_DEPTH_LEVEL: ${{ steps.resolve_depth.outputs.depth }}
         CACHING_DOCUMENTATION: 'false'
         ENABLE_MONITORING: 'false'
@@ -896,7 +881,7 @@ runs:
         git -C "$TARGET" worktree prune
         rm -rf "$BASE_SRC"
         git -C "$TARGET" worktree add --detach "$BASE_SRC" "$BASE_SHA"
-        uv run python "$ACTION_PATH/scripts/engine_adapter.py" base \
+        python "$ACTION_PATH/scripts/engine_adapter.py" base \
           --repo "$BASE_SRC" \
           --out "$BASE_DIR" \
           --name "$REPO_NAME" \
@@ -924,16 +909,13 @@ runs:
         # inputs. So a free-tier run (oidc, forced Gemini) and a BYO OpenRouter-key
         # run with no model pinned would share a key yet produce different base
         # analyses; the mode discriminator keeps them from reusing each other's cache.
-        key: cb-base-v2-${{ runner.os }}-${{ steps.base.outputs.baseline_sha }}-d${{ steps.resolve_depth.outputs.depth }}-${{ inputs.engine_ref }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
+        key: cb-base-v2-${{ runner.os }}-${{ steps.base.outputs.baseline_sha }}-d${{ steps.resolve_depth.outputs.depth }}-${{ inputs.codeboarding_version }}-${{ steps.llm.outputs.mode }}-${{ inputs.llm_provider }}-${{ inputs.agent_model }}-${{ inputs.parsing_model }}
 
     - name: Analyze PR head (incremental from base)
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review'
       id: analyze
       shell: bash
-      working-directory: codeboarding-engine
       env:
-        STATIC_ANALYSIS_CONFIG: ${{ github.workspace }}/codeboarding-engine/static_analysis_config.yml
-        PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
         DIAGRAM_DEPTH_LEVEL: ${{ steps.resolve_depth.outputs.depth }}
         CACHING_DOCUMENTATION: 'false'
         ENABLE_MONITORING: 'false'
@@ -986,13 +968,12 @@ runs:
         if [ "$EMPTY_BASE" = "true" ]; then
           head_args+=(--force-full)
         fi
-        uv run python "$ACTION_PATH/scripts/engine_adapter.py" "${head_args[@]}"
+        python "$ACTION_PATH/scripts/engine_adapter.py" "${head_args[@]}"
         if [ ! -f "$HEAD_DIR/analysis.json" ]; then
           echo "::error::Head analysis ran but analysis.json is missing."
           exit 1
         fi
-        echo "base_analysis=$BASE_DIR/analysis.json" 
-        $GITHUB_OUTPUT
+        echo "base_analysis=$BASE_DIR/analysis.json" >> "$GITHUB_OUTPUT"
         echo "head_analysis=$HEAD_DIR/analysis.json" >> $GITHUB_OUTPUT
 
     - name: Architecture health check (best-effort)
@@ -1000,10 +981,7 @@ runs:
       id: health
       continue-on-error: true
       shell: bash
-      working-directory: codeboarding-engine
       env:
-        STATIC_ANALYSIS_CONFIG: ${{ github.workspace }}/codeboarding-engine/static_analysis_config.yml
-        PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
         ACTION_PATH: ${{ github.action_path }}
         ARTIFACT_DIR: ${{ steps.base.outputs.head_dir }}
         TARGET_REPO: ${{ github.workspace }}/target-repo
@@ -1011,7 +989,7 @@ runs:
       run: |
         rm -f /tmp/cb-issues.txt
         # engine_adapter writes the WARNING/CRITICAL count (0 on any failure — best-effort).
-        uv run python "$ACTION_PATH/scripts/engine_adapter.py" health \
+        python "$ACTION_PATH/scripts/engine_adapter.py" health \
           --artifact-dir "$ARTIFACT_DIR" \
           --repo "$TARGET_REPO" \
           --name "$REPO_NAME" \
@@ -1085,7 +1063,7 @@ runs:
         path: |
           ${{ runner.temp }}/cb-sync/static_analysis.pkl
           ${{ runner.temp }}/cb-sync/static_analysis.sha
-        key: cb-sync-${{ runner.os }}-${{ inputs.engine_ref }}-d${{ steps.resolve_depth.outputs.depth }}-${{ steps.llm.outputs.cache_provider }}-${{ steps.llm.outputs.cache_agent_model }}-${{ steps.llm.outputs.cache_parsing_model }}-${{ steps.sync_seed.outputs.baseline_sha }}
+        key: cb-sync-${{ runner.os }}-${{ inputs.codeboarding_version }}-d${{ steps.resolve_depth.outputs.depth }}-${{ steps.llm.outputs.cache_provider }}-${{ steps.llm.outputs.cache_agent_model }}-${{ steps.llm.outputs.cache_parsing_model }}-${{ steps.sync_seed.outputs.baseline_sha }}
 
     # Same rationale as the review pipeline's seed step: the committed
     # analysis.json supplies component ids, but the incremental path also needs
@@ -1095,10 +1073,7 @@ runs:
       id: sync_seedcache
       continue-on-error: true
       shell: bash
-      working-directory: codeboarding-engine
       env:
-        STATIC_ANALYSIS_CONFIG: ${{ github.workspace }}/codeboarding-engine/static_analysis_config.yml
-        PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
         # The seed subcommand defaults to github_action attribution; sync-mode
         # telemetry must report as sync (setdefault never clobbers this).
         CODEBOARDING_SOURCE: 'sync'
@@ -1123,7 +1098,7 @@ runs:
         git -C "$TARGET_REPO" worktree prune
         rm -rf "$BASE_SRC"
         git -C "$TARGET_REPO" worktree add --detach "$BASE_SRC" "$BASELINE_SHA"
-        if uv run python "$ACTION_PATH/scripts/engine_adapter.py" seed \
+        if python "$ACTION_PATH/scripts/engine_adapter.py" seed \
              --repo "$BASE_SRC" \
              --out "$ANALYSIS_DIR" \
              --source-sha "$BASELINE_SHA" \
@@ -1140,10 +1115,7 @@ runs:
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'sync'
       id: sync_analyze
       shell: bash
-      working-directory: codeboarding-engine
       env:
-        STATIC_ANALYSIS_CONFIG: ${{ github.workspace }}/codeboarding-engine/static_analysis_config.yml
-        PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
         DIAGRAM_DEPTH_LEVEL: ${{ steps.resolve_depth.outputs.depth }}
         CACHING_DOCUMENTATION: 'false'
         ENABLE_MONITORING: 'false'
@@ -1186,7 +1158,7 @@ runs:
         )
         [ "$FORCE_FULL" = "true" ] && args+=(--force-full)
         LOG="${RUNNER_TEMP}/cb-sync-analyze.log"
-        uv run python "$ACTION_PATH/scripts/engine_adapter.py" analyze "${args[@]}" | tee "$LOG"
+        python "$ACTION_PATH/scripts/engine_adapter.py" analyze "${args[@]}" | tee "$LOG"
         MODE="$(sed -n 's/^analysis_mode=//p' "$LOG" | tail -1)"
         MODE="${MODE:-unknown}"
         echo "analysis_mode=$MODE" >> "$GITHUB_OUTPUT"
@@ -1417,9 +1389,7 @@ runs:
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'sync'
       id: sync_render
       shell: bash
-      working-directory: codeboarding-engine
       env:
-        PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
         ACTION_PATH: ${{ github.action_path }}
         ANALYSIS_DIR: ${{ steps.sync_seed.outputs.cb_dir }}
         RENDER_DIR: ${{ steps.sync_seed.outputs.render_dir }}
@@ -1433,14 +1403,14 @@ runs:
       run: |
         set -euo pipefail
         REPO_REF="https://github.com/${REPOSITORY}/blob/${TARGET_BRANCH}/${OUTPUT_DIR}"
-        uv run python "$ACTION_PATH/scripts/engine_adapter.py" render \
+        python "$ACTION_PATH/scripts/engine_adapter.py" render \
           --analysis "$ANALYSIS_DIR/analysis.json" \
           --out "$RENDER_DIR" \
           --repo-name "$REPO_NAME" \
           --repo-ref "$REPO_REF" \
           --format "$OUTPUT_FORMAT"
         if [ "$WRITE_ARCHITECTURE_MD" = "true" ]; then
-          uv run python "$ACTION_PATH/scripts/engine_adapter.py" concat \
+          python "$ACTION_PATH/scripts/engine_adapter.py" concat \
             --docs-dir "$RENDER_DIR" \
             --out "$ARCHITECTURE_FILE"
         fi
@@ -1470,7 +1440,7 @@ runs:
         path: |
           ${{ runner.temp }}/cb-sync/static_analysis.pkl
           ${{ runner.temp }}/cb-sync/static_analysis.sha
-        key: cb-sync-${{ runner.os }}-${{ inputs.engine_ref }}-d${{ steps.resolve_depth.outputs.depth }}-${{ steps.llm.outputs.cache_provider }}-${{ steps.llm.outputs.cache_agent_model }}-${{ steps.llm.outputs.cache_parsing_model }}-${{ steps.guard.outputs.target_sha }}
+        key: cb-sync-${{ runner.os }}-${{ inputs.codeboarding_version }}-d${{ steps.resolve_depth.outputs.depth }}-${{ steps.llm.outputs.cache_provider }}-${{ steps.llm.outputs.cache_agent_model }}-${{ steps.llm.outputs.cache_parsing_model }}-${{ steps.guard.outputs.target_sha }}
 
     - name: Commit and push synced architecture
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'sync'

--- a/scripts/engine_adapter.py
+++ b/scripts/engine_adapter.py
@@ -1,8 +1,11 @@
 """CLI adapter between the action and the CodeBoarding analysis ENGINE.
 
-No analysis logic lives here. The engine is the separate ``CodeBoarding/
-CodeBoarding`` repo, checked out at runtime into ``codeboarding-engine/``; this
-module just turns the action's shell steps into typed, tested calls into it.
+No analysis logic lives here. The engine is the published ``codeboarding`` PyPI
+package installed by the action and imported lazily inside each function
+(``codeboarding_workflows`` etc.); this module just turns the action's shell
+steps into typed, tested calls into it. The lazy imports mean this file imports
+fine without the package present — the tests stub those modules and assert we
+call the engine with the right args.
 
 Subcommands (all paths/refs come in as argv, never interpolated into source):
 

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -8,9 +8,9 @@
 #   FAST (no LLM, instant) — diff two existing analysis.json files and preview:
 #     scripts/run_local.sh --base-json BASE.json --head-json HEAD.json
 #
-#   FULL pipeline (needs OPENROUTER_API_KEY) — run the engine on two refs of a
-#   local repo, exactly like the action (committed-or-generated base, then
-#   incremental head), then diff + preview:
+#   FULL pipeline (needs OPENROUTER_API_KEY) — run the installed codeboarding
+#   package on two refs of a local repo, exactly like the action
+#   (committed-or-generated base, then incremental head), then diff + preview:
 #     export OPENROUTER_API_KEY=sk-or-...
 #     scripts/run_local.sh --repo /path/to/repo --base <ref> --head <ref>
 #
@@ -21,7 +21,7 @@
 set -euo pipefail
 
 ACTION_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ENGINE="${ENGINE:-$ACTION_DIR/../CodeBoarding}"
+ENGINE="${ENGINE:-}"
 OUT="$ACTION_DIR/.cb-local"
 DEPTH="1"
 DIRECTION="LR"
@@ -43,7 +43,7 @@ while [ $# -gt 0 ]; do
     --head) HEAD_REF="$2"; shift 2;;
     --base-json) BASE_JSON="$2"; shift 2;;
     --head-json) HEAD_JSON="$2"; shift 2;;
-    --engine) ENGINE="$2"; shift 2;;
+    --engine) ENGINE="$2"; shift 2;;  # optional local CodeBoarding checkout for engine development
     --out) OUT="$2"; shift 2;;
     --depth) DEPTH="$2"; shift 2;;
     --direction) DIRECTION="$2"; shift 2;;
@@ -60,17 +60,16 @@ done
 mkdir -p "$OUT"
 
 run_engine() {
-  ( cd "$ENGINE"
-    export STATIC_ANALYSIS_CONFIG="$ENGINE/static_analysis_config.yml" \
-           PROJECT_ROOT="$ENGINE" \
-           DIAGRAM_DEPTH_LEVEL="$DEPTH" \
+  (
+    if [ -n "$ENGINE" ]; then cd "$ENGINE"; fi
+    export DIAGRAM_DEPTH_LEVEL="$DEPTH" \
            CACHING_DOCUMENTATION="false" \
            ENABLE_MONITORING="false"
     # OPENROUTER_API_KEY is inherited from the environment (full mode requires it).
     # Pass the model only when set; empty -> engine's own valid per-provider default.
     if [ -n "$AGENT_MODEL" ]; then export AGENT_MODEL; fi
     if [ -n "$PARSING_MODEL" ]; then export PARSING_MODEL; fi
-    uv run python "$ACTION_DIR/scripts/engine_adapter.py" "$@" )
+    python "$ACTION_DIR/scripts/engine_adapter.py" "$@" )
 }
 
 if [ -n "$BASE_JSON" ] && [ -n "$HEAD_JSON" ]; then
@@ -81,7 +80,9 @@ else
   if [ -z "$REPO" ] || [ -z "$BASE_REF" ] || [ -z "$HEAD_REF" ]; then
     echo "Need either --base-json/--head-json, or --repo/--base/--head." >&2; exit 2
   fi
-  [ -d "$ENGINE" ] || { echo "Engine not found at $ENGINE (set --engine or \$ENGINE)." >&2; exit 2; }
+  if [ -n "$ENGINE" ] && [ ! -d "$ENGINE" ]; then
+    echo "Engine not found at $ENGINE (set --engine or install the codeboarding package)." >&2; exit 2
+  fi
   [ -n "${OPENROUTER_API_KEY:-}" ] || { echo "Export OPENROUTER_API_KEY for the full pipeline." >&2; exit 2; }
   REPO="$(cd "$REPO" && pwd)"
   BASE_SHA="$(git -C "$REPO" rev-parse "$BASE_REF^{commit}")"


### PR DESCRIPTION
## Summary
- install the CodeBoarding engine from the published PyPI package instead of checking out CodeBoarding/CodeBoarding
- replace engine_ref with codeboarding_version and update action cache keys
- update engine_adapter docs, local harness, and README usage to match the package-based runtime

## Validation
- ruby -e 'require "yaml"; YAML.load_file("action.yml")'
- python3.13 -m pip index versions codeboarding
- python3 -m unittest discover -s tests -v

## Self-test note
This repo's pull_request review workflow checks out the PR and runs the action with uses: ./, so the PR-open workflow should exercise this branch's action code. Slash-command issue_comment reruns may use the default branch checkout unless that workflow is changed to fetch the PR head explicitly.