### PR TITLE
fix: update Core dependency to 0.13.1

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -116,7 +116,3 @@ jobs:
         with:
           github_token: ${{ steps.codeboarding-app-token-client.outputs.token || steps.codeboarding-app-token-app.outputs.token || github.token }}
           llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}
-          # Integration-test Core PR #412, pinned to its current commit so this
-          # workflow exercises its Tree-sitter constraints reproducibly.
-          # action.yml accepts a PEP 508 suffix for unreleased engine builds.
-          codeboarding_version: '@ git+https://github.com/CodeBoarding/CodeBoarding.git@da89f3bf0b56e0a5afeb61e171892942c54766fe'

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -116,3 +116,7 @@ jobs:
         with:
           github_token: ${{ steps.codeboarding-app-token-client.outputs.token || steps.codeboarding-app-token-app.outputs.token || github.token }}
           llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          # Integration-test Core PR #412, pinned to its current commit so this
+          # workflow exercises its Tree-sitter constraints reproducibly.
+          # action.yml accepts a PEP 508 suffix for unreleased engine builds.
+          codeboarding_version: '@ git+https://github.com/CodeBoarding/CodeBoarding.git@da89f3bf0b56e0a5afeb61e171892942c54766fe'

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Review mode does not need `contents: write`: PR-specific generated files are sto
 | `mode` | both | `review` | `review` posts the PR architecture-diff comment; `sync` analyzes on push and commits the architecture (`analysis.json` + rendered docs) to `target_branch`, keeping it versioned and current. |
 | `github_token` | both | `${{ github.token }}` | Token for GitHub API calls; in review mode it posts or updates the PR comment. |
 | `push_token` | sync | `${{ github.token }}` | Token used for sync-mode pushes to `target_branch`. The workflow token can push when the workflow grants `permissions: contents: write`. Separate from `github_token` so commenting can use a GitHub App token while the push uses the workflow token. |
-| `codeboarding_version` | both | `0.13.0` | CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility. |
+| `codeboarding_version` | both | `0.13.1` | CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility. |
 | `depth_level` | both | empty (`2` for cold starts) | Analysis depth for first analysis and `force_full` rebuilds. Max depends on tier: **3** on the free hosted tier, **10** with a CodeBoarding license or your own `llm_api_key`. Once `.codeboarding/analysis.json` exists, its `metadata.depth_level` is the source of truth: sync runs incremental at the baseline depth, and review analyzes the PR head at the committed baseline depth so the diff is apples-to-apples (clamped to the tier max). |
 | `render_depth` | review | `1` | Display depth for the PR diagram. Keep `1` for a clean top-level view. |
 | `diagram_direction` | review | `LR` | Mermaid direction: `LR`, `TD`, `TB`, `RL`, or `BT`. |
@@ -315,7 +315,7 @@ Full local pipeline:
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-...
-python -m pip install codeboarding==0.13.0
+python -m pip install codeboarding==0.13.1
 codeboarding-setup --auto-install-npm
 scripts/run_local.sh --repo /path/to/repo --base <base-ref> --head <head-ref>
 ```

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
   codeboarding_version:
     description: 'CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility; set to a newer released version to opt into newer engine releases.'
     required: false
-    default: '0.13.0'
+    default: '0.13.1'
   depth_level:
     description: 'Analysis depth for cold-start or force_full rebuilds. Max depends on tier: 3 on the free hosted tier, 10 with a CodeBoarding license or your own llm_api_key. Once .codeboarding/analysis.json exists, its metadata.depth_level is the source of truth: sync runs incremental at the baseline depth, and review analyzes the PR head at the committed baseline depth so the diff is apples-to-apples (clamped to the tier max). Empty (default): 2 for cold starts.'
     required: false


### PR DESCRIPTION
## Summary

- update the action's default CodeBoarding engine from `0.13.0` to `0.13.1`
- update the documented input default and local installation command
- rely exclusively on Core `0.13.1` for the compatible Tree-sitter runtime and grammar pins; the action carries no duplicate Tree-sitter constraints

## Why

Core `0.13.1` includes the dependency fix from [CodeBoarding Core PR #412](https://github.com/CodeBoarding/CodeBoarding/pull/412). Updating the action's normal engine dependency gives every action run the fixed dependency set while keeping dependency ownership in Core.

## Verification

- [x] Installed `codeboarding==0.13.1` from PyPI on Python 3.12
- [x] Confirmed `tree-sitter==0.25.2` and all eight grammar packages resolve to Core's exact pinned versions
- [x] Ran a `SourceInspector.find_call_sites` Tree-sitter parser smoke test
- [x] `python3 -m unittest discover -s tests` (176 passed)
- [x] `pre-commit run --all-files`
- [x] `actionlint`
- [x] Confirm the CodeBoarding dogfood workflow succeeds using the action's new default engine


Dogfood evidence: [released-package run passed](https://github.com/CodeBoarding/CodeBoarding-action/actions/runs/29333387512) using the action's `0.13.1` default. The first attempt occurred during PyPI CDN propagation and could only see versions through `0.13.0`; the subsequent run installed `0.13.1` and completed successfully.
