### PR TITLE
fix: update CodeBoarding dependency to 0.13.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Review mode does not need `contents: write`: PR-specific generated files are sto
 | `mode` | both | `review` | `review` posts the PR architecture-diff comment; `sync` analyzes on push and commits the architecture (`analysis.json` + rendered docs) to `target_branch`, keeping it versioned and current. |
 | `github_token` | both | `${{ github.token }}` | Token for GitHub API calls; in review mode it posts or updates the PR comment. |
 | `push_token` | sync | `${{ github.token }}` | Token used for sync-mode pushes to `target_branch`. The workflow token can push when the workflow grants `permissions: contents: write`. Separate from `github_token` so commenting can use a GitHub App token while the push uses the workflow token. |
-| `codeboarding_version` | both | `0.13.1` | CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility. |
+| `codeboarding_version` | both | `0.13.3` | CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility. |
 | `depth_level` | both | empty (`2` for cold starts) | Analysis depth for first analysis and `force_full` rebuilds. Max depends on tier: **3** on the free hosted tier, **10** with a CodeBoarding license or your own `llm_api_key`. Once `.codeboarding/analysis.json` exists, its `metadata.depth_level` is the source of truth: sync runs incremental at the baseline depth, and review analyzes the PR head at the committed baseline depth so the diff is apples-to-apples (clamped to the tier max). |
 | `render_depth` | review | `1` | Display depth for the PR diagram. Keep `1` for a clean top-level view. |
 | `diagram_direction` | review | `LR` | Mermaid direction: `LR`, `TD`, `TB`, `RL`, or `BT`. |
@@ -315,7 +315,7 @@ Full local pipeline:
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-...
-python -m pip install codeboarding==0.13.1
+python -m pip install codeboarding==0.13.3
 codeboarding-setup --auto-install-npm
 scripts/run_local.sh --repo /path/to/repo --base <base-ref> --head <head-ref>
 ```

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
   codeboarding_version:
     description: 'CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility; set to a newer released version to opt into newer engine releases.'
     required: false
-    default: '0.13.2'
+    default: '0.13.3'
   depth_level:
     description: 'Analysis depth for cold-start or force_full rebuilds. Max depends on tier: 3 on the free hosted tier, 10 with a CodeBoarding license or your own llm_api_key. Once .codeboarding/analysis.json exists, its metadata.depth_level is the source of truth: sync runs incremental at the baseline depth, and review analyzes the PR head at the committed baseline depth so the diff is apples-to-apples (clamped to the tier max). Empty (default): 2 for cold starts.'
     required: false


### PR DESCRIPTION
Re-pin the analysis engine to `codeboarding` **0.13.3**:
- `action.yml` — `codeboarding_version` input `default` → `0.13.3`
- `README.md` — inputs-table row and the `pip install codeboarding==` example → `0.13.3` (these had drifted a version behind `action.yml`; now realigned)

⚠️ **Do not merge until `codeboarding==0.13.3` is published to PyPI** — the install step runs `pip install codeboarding==0.13.3`, so merging earlier would break consumers' next run and the repo's own dogfood CI.

The action's own version is release-please managed and is intentionally untouched here.