### PR TITLE
fix: don't let a late failure erase a review that already posted

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1406,7 +1406,11 @@ runs:
 
         echo "body_file=$BODY_FILE" >> "$GITHUB_OUTPUT"
 
+    # `id` so the failure paths below can tell "the review never got posted" from
+    # "the review posted fine and something after it broke". They share this step's
+    # sticky header, so without that distinction they REPLACE a good review.
     - name: Post sticky PR comment
+      id: review_comment
       if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review'
       uses: marocchino/sticky-pull-request-comment@v2
       with:
@@ -1795,7 +1799,7 @@ runs:
         fi
 
     - name: Post quota-exhausted comment
-      if: failure() && steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review' && steps.quota.outputs.exhausted == 'true'
+      if: failure() && steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review' && steps.quota.outputs.exhausted == 'true' && steps.review_comment.outcome != 'success'
       continue-on-error: true
       uses: marocchino/sticky-pull-request-comment@v2
       with:
@@ -1815,8 +1819,12 @@ runs:
           <sub>codeboarding-action · run ${{ github.run_id }}</sub>
         GITHUB_TOKEN: ${{ inputs.github_token }}
 
+    # Not posted when the review itself already went out: these comments reuse the
+    # review's sticky header, so posting one REPLACES the architecture diff the user
+    # came for. A step failing after the review has been published (the walkthrough
+    # add-on, an artifact upload) cannot un-publish it, and must not erase it either.
     - name: Post failure comment
-      if: failure() && steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review' && steps.quota.outputs.exhausted != 'true'
+      if: failure() && steps.guard.outputs.skip != 'true' && steps.guard.outputs.mode == 'review' && steps.quota.outputs.exhausted != 'true' && steps.review_comment.outcome != 'success'
       continue-on-error: true
       uses: marocchino/sticky-pull-request-comment@v2
       with:


### PR DESCRIPTION
## The bug

The failure and quota comments reuse the **review comment's sticky header**, so posting
either one *replaces* the architecture diff instead of adding to it. Any step that fails
**after** the review has been published therefore deletes the thing the user came for, and
the PR is left showing "Architecture review · failed" for a review that actually worked.

Seen on [CodeBoarding-webview#22](https://github.com/CodeBoarding/CodeBoarding-webview/pull/22)
([run](https://github.com/CodeBoarding/CodeBoarding-webview/actions/runs/30686098746)) — every
step that matters succeeded:

```
diagram                 outcome=success
body                    outcome=success
upload_review_artifact  outcome=success
Post sticky PR comment  outcome=success   ← the review WAS published
<enrichment step>       outcome=failure   ← then this failed
```

…and the failure comment then overwrote it. The trigger there was an add-on step on an
unmerged branch, but the defect is on `main` and any late failure hits it — a flaky
`upload-artifact`, a transient API error while posting.

## The fix

Give the review comment an `id`, and gate both failure paths on it:

```yaml
- name: Post sticky PR comment
  id: review_comment
  …

- name: Post failure comment
  if: … && steps.review_comment.outcome != 'success'
```

A step failing after publication cannot un-publish the review, so it must not erase it.

## Genuine failures still report

`!= 'success'` rather than `== 'failure'` on purpose — it fails **open**:

| Case | `review_comment.outcome` | Failure comment |
|---|---|---|
| Analysis fails before the comment | `skipped` / empty | posts (unchanged) |
| The comment step itself fails | `failure` | posts (unchanged) |
| Quota exhausted before the review | `skipped` | quota comment posts (unchanged) |
| **Review posts, later step fails** | `success` | **suppressed** (the fix) |
| Sync mode | n/a | already gated on `mode == 'review'` |

## Notes

- `action.yml` only; `action.yml` is byte-identical between `v1` and `main`, so this
  applies cleanly to the shipping code.
- `actionlint` reports nothing for `action.yml`. It does flag `create-github-app-token`
  inputs in this repo's own workflows, but that is pre-existing, untouched by this PR, and
  does not reproduce under the version CI pins (`v1.7.7`; local was `1.7.12`).
- Per `AGENT.md`, merging alone ships nothing — this needs a release to re-point `@v1`
  before consumers pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
