### PR TITLE
Update CodeBoarding dependency to 0.13.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Review mode does not need `contents: write`: PR-specific generated files are sto
 | `mode` | both | `review` | `review` posts the PR architecture-diff comment; `sync` analyzes on push and commits the architecture (`analysis.json` + rendered docs) to `target_branch`, keeping it versioned and current. |
 | `github_token` | both | `${{ github.token }}` | Token for GitHub API calls; in review mode it posts or updates the PR comment. |
 | `push_token` | sync | `${{ github.token }}` | Token for sync-mode delivery. The workflow token can push when the workflow grants `permissions: contents: write`. Separate from `github_token` so commenting can use a GitHub App token while the push uses the workflow token. In `sync_strategy: pull_request` it also opens/updates the rolling PR, so it must additionally carry `pull-requests: write`. |
-| `codeboarding_version` | both | `0.13.4` | CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility. |
+| `codeboarding_version` | both | `0.13.5` | CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility. |
 | `depth_level` | both | empty (`2` for cold starts) | Analysis depth for first analysis and `force_full` rebuilds. Max depends on tier: **3** on the free hosted tier, **10** with a CodeBoarding license or your own `llm_api_key`. Once `.codeboarding/analysis.json` exists, its `metadata.depth_level` is the source of truth: sync runs incremental at the baseline depth, and review analyzes the PR head at the committed baseline depth so the diff is apples-to-apples (clamped to the tier max). |
 | `render_depth` | review | `1` | Display depth for the PR diagram. Keep `1` for a clean top-level view. |
 | `diagram_direction` | review | `LR` | Mermaid direction: `LR`, `TD`, `TB`, `RL`, or `BT`. |
@@ -362,7 +362,7 @@ Full local pipeline:
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-...
-python -m pip install codeboarding==0.13.4
+python -m pip install codeboarding==0.13.5
 codeboarding-setup --auto-install-npm
 scripts/run_local.sh --repo /path/to/repo --base <base-ref> --head <head-ref>
 ```

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
   codeboarding_version:
     description: 'CodeBoarding PyPI package version used as the analysis engine. Pin for reproducibility; set to a newer released version to opt into newer engine releases.'
     required: false
-    default: '0.13.4'
+    default: '0.13.5'
   depth_level:
     description: 'Analysis depth for cold-start or force_full rebuilds. Max depends on tier: 3 on the free hosted tier, 10 with a CodeBoarding license or your own llm_api_key. Once .codeboarding/analysis.json exists, its metadata.depth_level is the source of truth: sync runs incremental at the baseline depth, and review analyzes the PR head at the committed baseline depth so the diff is apples-to-apples (clamped to the tier max). Empty (default): 2 for cold starts.'
     required: false

--- a/scripts/engine_adapter.py
+++ b/scripts/engine_adapter.py
@@ -78,6 +78,7 @@ try:
     from diagram_analysis import RunContext, RunPaths
     from diagram_analysis.exceptions import IncrementalCacheMissingError
     from diagram_analysis.io_utils import write_fingerprint
+    from logging_config import setup_logging
     from static_analyzer import get_static_analysis
     from static_analyzer.analysis_cache import StaticAnalysisCache
     from static_analyzer.cluster_helpers import build_all_cluster_results
@@ -85,6 +86,7 @@ except Exception:  # engine package not installed (metadata-only subcommands don
     BaselineUnavailableError = IncrementalCacheMissingError = _MissingEngine = type("_MissingEngine", (Exception,), {})
     run_full = run_incremental = render_docs = None
     RunContext = RunPaths = None
+    setup_logging = None
     get_static_analysis = StaticAnalysisCache = build_all_cluster_results = None
     hash_repo_source_files = write_fingerprint = None
 
@@ -718,6 +720,7 @@ def main(argv=None) -> int:
     os.environ.setdefault("CODEBOARDING_SOURCE", source)
     if args.cmd in _ENGINE_COMMANDS:
         _require_engine(args.cmd)
+        setup_logging(default_level=os.getenv("CODEBOARDING_LOG_LEVEL", "INFO"))
     try:
         if args.cmd == "base":
             run_base(args.repo, args.out, args.name, args.run_id, args.depth, args.source_sha)

--- a/tests/test_engine_adapter.py
+++ b/tests/test_engine_adapter.py
@@ -91,6 +91,7 @@ da = _preload("diagram_analysis", RunPaths=_RunPaths, RunContext=_RunContext)
 da.exceptions = exc
 _preload("diagram_analysis.analysis_json", UnifiedAnalysisJson=_InitialUnifiedAnalysisJson)
 _preload("diagram_analysis.io_utils", write_fingerprint=lambda *a, **k: None)
+_preload("logging_config", setup_logging=lambda **kwargs: None)
 _preload("agents.content_hash", hash_repo_source_files=lambda *a, **k: {})
 _preload("agents")
 _preload("codeboarding_workflows.rendering", render_docs=lambda *args, **kwargs: None)
@@ -113,6 +114,7 @@ _STUBBED = [
     "diagram_analysis.analysis_json",
     "diagram_analysis.exceptions",
     "diagram_analysis.io_utils",
+    "logging_config",
     "health",
     "health.models",
     "health.runner",
@@ -218,6 +220,33 @@ class TestAnalysis(_Base):
             ]
         )
         self.assertEqual(rf.calls[0]["depth_level"], 2)
+
+    def test_main_enables_engine_console_logging(self):
+        self._install()
+        setup_logging = _Rec()
+        with (
+            patch.object(engine_adapter, "setup_logging", setup_logging),
+            patch.dict(os.environ, {"CODEBOARDING_LOG_LEVEL": "DEBUG"}),
+        ):
+            engine_adapter.main(
+                [
+                    "base",
+                    "--repo",
+                    "/repo",
+                    "--out",
+                    "/out",
+                    "--name",
+                    "myrepo",
+                    "--run-id",
+                    "rid-base",
+                    "--depth",
+                    "2",
+                    "--source-sha",
+                    "abc123",
+                ]
+            )
+
+        self.assertEqual(setup_logging.calls, [{"default_level": "DEBUG"}])
 
     def test_main_sets_github_action_source(self):
         rf = _Rec()

--- a/tests/test_sync_subcommands.py
+++ b/tests/test_sync_subcommands.py
@@ -89,6 +89,7 @@ da = _preload("diagram_analysis", RunPaths=_RunPaths, RunContext=_RunContext)
 da.exceptions = exc
 _preload("diagram_analysis.analysis_json", UnifiedAnalysisJson=_InitialUnifiedAnalysisJson)
 _preload("diagram_analysis.io_utils", write_fingerprint=lambda *a, **k: None)
+_preload("logging_config", setup_logging=lambda **kwargs: None)
 _preload("agents.content_hash", hash_repo_source_files=lambda *a, **k: {})
 _preload("agents")
 _preload("health.models", Severity=_InitialSeverity)
@@ -111,6 +112,7 @@ _STUBBED = [
     "diagram_analysis.analysis_json",
     "diagram_analysis.exceptions",
     "diagram_analysis.io_utils",
+    "logging_config",
     "static_analyzer",
     "static_analyzer.analysis_cache",
     "static_analyzer.cluster_helpers",


### PR DESCRIPTION
## Summary
- update the default CodeBoarding engine version to 0.13.5
- refresh README references for the default/local install version

## Validation
- uv run --with pytest pytest