### PR TITLE
feat: add manual release trigger

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,12 @@ name: release-please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      release_as:
+        description: 'Optional version to force, for example 1.10.0. Leave empty to use Conventional Commits.'
+        type: string
+        required: false
 
 permissions:
   contents: write
@@ -21,6 +27,7 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          release-as: ${{ inputs.release_as || '' }}
 
       # Move the moving major tag here rather than in release-major-tag.yml: a
       # release created with GITHUB_TOKEN does NOT trigger other workflows, so the


### PR DESCRIPTION
## Summary

- add a manual `workflow_dispatch` trigger to the release-please workflow
- accept an optional `release_as` version to force a release PR when Conventional Commit detection cannot infer one
- preserve the existing automatic push-to-main behavior when no version is supplied

## Usage

Open **Actions → release-please → Run workflow** and enter a version such as `1.10.0`. Leave it empty to run normal Conventional Commit detection.

## Validation

- `git diff --check`
- actionlint and pre-commit run in PR CI (not installed in the local environment)