### PR TITLE
fix: use stable PR route for webview links

### DIFF
--- a/scripts/action/build-review-comment.sh
+++ b/scripts/action/build-review-comment.sh
@@ -6,7 +6,9 @@ if [ "$N_CHANGED" = "1" ]; then
   COMPONENT_NOUN="component"
 fi
 RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-WEBVIEW_URL="https://app.codeboarding.org/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}?run=${GITHUB_RUN_ID}"
+# Stable PR route: the webview resolves the repo/PR's latest artifact itself,
+# so the link stays valid across runs instead of pinning one run id.
+WEBVIEW_URL="https://app.codeboarding.org/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
 BODY="${RUNNER_TEMP}/review-comment.md"
 printf '### CodeBoarding review\n\n**Status:** %s changed %s\n' "$N_CHANGED" "$COMPONENT_NOUN" > "$BODY"
 printf '\nSee the full change in [CodeBoarding](%s).\n' "$WEBVIEW_URL" >> "$BODY"


### PR DESCRIPTION
## What

The review-comment webview link appended `?run=<run_id>`, pinning the link to one workflow run:

`https://app.codeboarding.org/{owner}/{repo}/pull/{pr}?run=<run_id>`

The webview resolves the repo/PR's latest artifact itself, so the comment now links the bare stable route, which stays valid across runs:

`https://app.codeboarding.org/{owner}/{repo}/pull/{pr}`

(Rebased onto main across the #69 v2 restructure — the fix now lands in `scripts/action/build-review-comment.sh` instead of the removed `build_cta.py`.)

## Release

Merging this also makes release-please cut the release that finally ships the **CodeBoarding 0.13.8** engine pin: the pin landed on main as a `chore:` commit after v1.10.2, so it was never released — every released action version still installs 0.13.7. This `fix:`-typed commit triggers the release PR (squash-merge keeps the title release-please reads); merge that release PR to tag it and re-point `v1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)