### PR TITLE
docs: use gemini-3.7-flash in the model-selection example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ All model inputs are optional and are passed directly to Core without action-sid
 
 ```yaml
         with:
-          model: google/gemini-3-flash-preview
+          model: google/gemini-3.7-flash
           agent_model: anthropic/claude-sonnet-4 # optional analysis-only override
           parsing_model: openai/gpt-5-mini       # optional parsing-only override
 ```


### PR DESCRIPTION
Refreshes the model-selection example, which still showed `google/gemini-3-flash-preview`. CodeBoarding#485 moves the default agent model for every Gemini-serving provider to the GA `gemini-3.7-flash`.

## Why this is only a docs change

`main` carries **no hardcoded model defaults**. All three model inputs (`model`, `agent_model`, `parsing_model`) default to empty, and `scripts/action/with-auth.sh` exports `AGENT_MODEL` / `PARSING_MODEL` only when something was actually supplied. So when a consumer pins nothing, the action already falls through to Core's per-provider defaults in `LLM_PROVIDERS` — and CodeBoarding#485 updates those. The action picks up the new default on its own; the example was just the last place naming the old model.

`gemini-3.7-flash` is GA, newer, and cheaper than the preview it replaces, at the same 1M context: $0.38/$1.88 per 1M in/out versus $0.50/$3.00. On the hosted tier that spend is CodeBoarding's, so it is a direct saving.

## Heads-up for `feat/sync-pull-request-strategy`

That branch still carries the older shape, where `action.yml` hardcodes `AGENT_MODEL="${AGENT_MODEL:-google/gemini-3-flash-preview}"` and `PARSING_MODEL="${PARSING_MODEL:-google/gemini-3.1-flash-lite-preview}"` in two places (hosted tier and BYO-key OpenRouter), plus both input descriptions and the README inputs table. If it merges as-is it will reintroduce the preview model as the action's default and shadow Core's. Worth rebasing those defaults away rather than updating them, since `main` has deliberately stopped defaulting model names action-side.
