### PR TITLE
fix: install tqdm, which the pinned engine imports but does not require

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -154,7 +154,21 @@ runs:
     - name: Install CodeBoarding
       if: steps.guard.outputs.skip != 'true'
       shell: bash
-      run: python -m pip install --disable-pip-version-check 'codeboarding==0.13.8'
+      # tqdm is imported by the pinned CLI but missing from its dependencies. It
+      # used to arrive through openai, which dropped it in 3.3.0, so every fresh
+      # resolve since then installs a CLI that cannot start. Naming it here is a
+      # workaround for that packaging gap, not a dependency of this action;
+      # remove it once the engine declares its own.
+      run: |
+        python -m pip install --disable-pip-version-check 'codeboarding==0.13.8' tqdm
+        # Fail here, with the reason, rather than mid-analysis with a traceback:
+        # pinning a release does not pin what its dependencies resolve to. Run
+        # the console script, not `python -c`, which would put the analyzed
+        # repository's own main.py ahead of the CLI's on sys.path.
+        codeboarding --help >/dev/null || {
+          echo "::error::The installed CodeBoarding CLI cannot start; a dependency it imports is missing."
+          exit 1
+        }
 
     - name: Configure analysis authentication
       if: steps.guard.outputs.skip != 'true'


### PR DESCRIPTION
Every CodeBoarding run is currently failing, on `@v1` and `@v2`, with:

```
File ".../codeboarding_cli/commands/full_analysis.py", line 5, in <module>
    from tqdm import tqdm
ModuleNotFoundError: No module named 'tqdm'
```

## Why now, when nothing here changed

1. The pinned CLI imports `tqdm` in `codeboarding_cli/commands/full_analysis.py`, which `main.py` imports **unconditionally** — so nothing runs, not just full analyses.
2. `tqdm` is **not** a declared dependency of `codeboarding`.
3. It only ever arrived transitively, through `openai`.
4. **`openai` 3.3.0 dropped `tqdm`** from its requirements.

Pinning `codeboarding==0.13.8` pins the release, not what its dependencies resolve to, so the same install line started producing a CLI that cannot start.

Verified rather than inferred: a venv resolved a few hours before the breakage has `openai 3.1.0`, whose metadata still lists `tqdm`, and the CLI runs. A fresh resolve today gives `openai 3.3.0` and no `tqdm`:

```
openai -> 3.3.0
tqdm   -> (ABSENT)
```

## What this does

Names `tqdm` in the install. That is a workaround for a packaging gap in the engine, commented as such, and should be removed once `codeboarding` declares its own dependency — the real fix belongs upstream, in the engine's `pyproject.toml`.

It also checks the CLI can start, so a missing dependency fails at the install step with a stated reason instead of surfacing as a traceback part way into an analysis, after the progress comment has been posted.

That check runs the **console script**, not `python -c 'import main'`. `python -c` puts the current directory on `sys.path`, and the current directory is the workspace, so any analyzed repository with its own `main.py` would shadow the CLI's. Confirmed both ways against a stray `main.py`: `python -c 'import main'` imported the local file, the console script did not.

## Follow-up worth considering

This will recur. The action pins one package but installs an unpinned transitive graph, so any dependency of a dependency can break every consumer overnight. A constraints file, or `pip install --require-hashes` against a lock, would make the install reproducible. Out of scope here — this PR is the unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
