### PR TITLE
docs: review on every push, now that a push costs a delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ permissions:
   issues: write
   id-token: write
 
+# One review at a time per pull request. Two pushes in quick succession would
+# otherwise analyze concurrently, and both would start from the same older
+# analysis instead of the newer one continuing from its predecessor. They also
+# share one sticky comment, so whichever finishes last wins — which can be the
+# run for the older commit. Queue rather than cancel, so a /codeboarding command
+# waits for a running review instead of killing it.
+concurrency:
+  group: codeboarding-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   review:
     if: >
@@ -45,6 +55,8 @@ jobs:
 Automatic runs update one sticky **CodeBoarding review** comment. A trusted repository owner, member, or collaborator can comment `/codeboarding` to analyze the current PR head again, including on fork PRs; every command creates a new result comment.
 
 `synchronize` re-runs the review on every push to the branch. Each of those runs covers only the commits pushed since the previous one, so a push costs a fraction of a first analysis — and a pushed commit is the only thing that builds the reusable analysis, since GitHub gives comment-triggered runs a read-only cache. Drop `synchronize` from the list if you would rather spend one analysis per pull request than one per push.
+
+Keep the `concurrency` block if you keep `synchronize`: it is what makes a push continue from the push before it, and what stops a slower run for an older commit from overwriting the review comment for a newer one. Set `cancel-in-progress: true` instead to abandon a superseded run rather than queue it, which costs less when branches are pushed to rapidly, at the price of no analysis for the commits in between.
 
 | Command | What it does |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ name: CodeBoarding review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
 
@@ -43,6 +43,8 @@ jobs:
 ```
 
 Automatic runs update one sticky **CodeBoarding review** comment. A trusted repository owner, member, or collaborator can comment `/codeboarding` to analyze the current PR head again, including on fork PRs; every command creates a new result comment.
+
+`synchronize` re-runs the review on every push to the branch. Each of those runs covers only the commits pushed since the previous one, so a push costs a fraction of a first analysis — and a pushed commit is the only thing that builds the reusable analysis, since GitHub gives comment-triggered runs a read-only cache. Drop `synchronize` from the list if you would rather spend one analysis per pull request than one per push.
 
 | Command | What it does |
 |---|---|


### PR DESCRIPTION
Adds `synchronize` to the recommended `pull_request` trigger, and the per-pull-request `concurrency` block that makes it safe.

The trigger list deliberately left `synchronize` out, because every run used to re-derive the whole analysis and one run per push was not worth paying for. That reason is gone: a run now continues from the pull request's previous analysis and covers only the commits pushed since it.

There is a second reason, which #86 documents. A pushed commit is the **only** thing that builds that reusable analysis — GitHub gives comment-triggered runs a read-only cache token, so a repository reviewed exclusively through `/codeboarding` re-derives the head from the base every time.

Measured on a real 17-file pull request in CodeBoarding-webview: the head analysis was 4m26s of the 6.5-minute run. With a chain in place, a run after two more commits covers those two commits, not all seventeen.

## Why the concurrency block is part of this, not a nicety

Recommending per-push runs without serialization invites two races, both raised in review:

1. **The reuse silently does not happen.** Two pushes in quick succession analyze concurrently, so both restore the same older entry and neither continues from the other — exactly the saving this PR exists to deliver.
2. **A stale review can win.** Every `pull_request` run writes the same sticky header, `codeboarding-review` ([guard.sh:122-123](https://github.com/CodeBoarding/CodeBoarding-action/blob/main/scripts/action/guard.sh#L122-L123)) — only `issue_comment` runs get a per-run header. So whichever run finishes last overwrites the comment, and that can be the run for the older commit. The pull request then shows a diagram for a superseded head.

The example now queues one review per pull request, matching what this repository's own workflow has always done, and the README states what `cancel-in-progress: true` trades instead.

## Worth considering separately

The concurrency block protects consumers who copy the example. Anyone who adds `synchronize` to an existing workflow without it still hits the sticky-comment race. An action-side guard — refusing to overwrite a comment that already describes a newer commit — would make that safe regardless of workflow shape. Out of scope here.

Docs only — no behaviour change in the action. This repository's own workflow is left as it is, since that is a spending decision rather than a recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)