### PR TITLE
fix(review): stop labelling a base with the run that computed it

### DIFF
--- a/scripts/action/analyze.sh
+++ b/scripts/action/analyze.sh
@@ -96,14 +96,19 @@ stage() {
   # time rather than carried in the state directory, so a bundle can never
   # inherit the label of the one it was seeded from.
   python3 -c 'import json,os,sys
-json.dump({
-    "kind": sys.argv[2],
+kind = sys.argv[2]
+marker = {
+    "kind": kind,
     "engine_version": os.environ.get("ENGINE_VERSION", ""),
     "cfg_hash": os.environ.get("CFG_HASH", ""),
     "merge_base_sha": os.environ.get("REVIEW_BASE_SHA", ""),
-    "head_sha": os.environ.get("REVIEW_HEAD_SHA", ""),
-    "pr_number": os.environ.get("PR_NUMBER", ""),
-}, open(sys.argv[1], "w"), indent=2)' "$STAGE_DIR/$kind/metadata.json" "$kind"
+}
+# A base describes one commit and is shared by every pull request that forks
+# there, so the run that happened to compute it is not part of its identity.
+if kind == "warmstart":
+    marker["pr_number"] = os.environ.get("PR_NUMBER", "")
+    marker["head_sha"] = os.environ.get("REVIEW_HEAD_SHA", "")
+json.dump(marker, open(sys.argv[1], "w"), indent=2)' "$STAGE_DIR/$kind/metadata.json" "$kind"
 }
 
 analyze_sync() {

--- a/tests/test_action_state.py
+++ b/tests/test_action_state.py
@@ -293,6 +293,20 @@ class ReviewChainTests(unittest.TestCase):
         warmstart = json.loads((self.stage_dir / "warmstart" / "metadata.json").read_text())
         self.assertEqual(warmstart["kind"], "warmstart")
         self.assertEqual(warmstart["merge_base_sha"], "merge-base-sha")
+        # A warm-start bundle belongs to one pull request; a base does not.
+        self.assertEqual(warmstart["pr_number"], "42")
+
+    def test_a_base_is_not_labelled_with_the_run_that_computed_it(self) -> None:
+        # One base serves every pull request forking from that commit, so the
+        # run that happened to build it is not part of what the bundle is.
+        _state(self.base_dir)
+        self._analyze(RENEW_BASE="true")
+
+        base = json.loads((self.stage_dir / "base" / "metadata.json").read_text())
+        self.assertEqual(base["kind"], "base")
+        self.assertEqual(base["merge_base_sha"], "merge-base-sha")
+        self.assertNotIn("pr_number", base)
+        self.assertNotIn("head_sha", base)
 
     def test_a_bundle_never_inherits_the_label_of_its_seed(self) -> None:
         # A fetched base bundle carries kind=base, and the head is seeded by


### PR DESCRIPTION
Missed the 1.12.0 release: it was pushed to #93's branch after that PR merged, so it is on the branch but not in `main`.

## The defect

A base graph describes one commit and is shared by **every** pull request that forks there — the name is `codeboarding-base-<cfg>-<merge_base_sha>`, with no pull request in it. But its `metadata.json` carried the `pr_number` and `head_sha` of whichever run happened to build it:

```json
{ "kind": "base", "merge_base_sha": "c9e4c7cf…", "pr_number": "92", "head_sha": "…" }
```

So a shared object looked owned by one pull request it has nothing to do with. Anyone reading it would reasonably conclude bases are per pull request, and either dedupe them wrongly or distrust the sharing.

Those two fields are now written only for a warm-start bundle, which genuinely does belong to one pull request. A base marker is `kind`, `merge_base_sha`, `cfg_hash`, `engine_version`.

## Verification

`test_a_base_is_not_labelled_with_the_run_that_computed_it` asserts a staged base has no `pr_number` or `head_sha`, alongside the existing check that a warm-start does. 94 tests pass.

Metadata only — no behavioural change to what is published, fetched or reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
