### PR TITLE
fix(review): say when artifacts cannot be listed

### DIFF
--- a/scripts/action/fetch-state.sh
+++ b/scripts/action/fetch-state.sh
@@ -32,7 +32,14 @@ trusted='[.artifacts[]?
   | sort_by(.created_at) | last'
 selected="" expires="" rejected=0 page=1
 while [ "$page" -le 10 ]; do
-  listing="$(api "repos/$REPOSITORY/actions/artifacts?name=$ARTIFACT_NAME&per_page=100&page=$page" 2>/dev/null || true)"
+  if ! listing="$(api "repos/$REPOSITORY/actions/artifacts?name=$ARTIFACT_NAME&per_page=100&page=$page" 2>/dev/null)"; then
+    # A denied listing and an empty one are the same silence otherwise, and the
+    # denial is permanent: the run publishes fine, since uploading needs no
+    # permission, so a repository can look like it is always cold and never
+    # learn why.
+    echo "::warning::Could not list artifacts in $REPOSITORY. Add 'actions: read' to the job's permissions to reuse previous analyses; deriving from the base for now."
+    exit 0
+  fi
   [ -n "$listing" ] || break
   returned="$(jq -r '.artifacts | length' <<< "$listing" 2>/dev/null || echo 0)"
   [ "${returned:-0}" -gt 0 ] || break

--- a/tests/test_action_state.py
+++ b/tests/test_action_state.py
@@ -671,3 +671,36 @@ class ArtifactProvenanceTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertTrue((self.root / "out").exists())
+
+
+class UnreadableArtifactsTests(unittest.TestCase):
+    """Listing needs actions: read; uploading does not. Without it a repository
+    publishes on every run and reads on none, which looks like a permanent miss."""
+
+    def test_it_says_why_when_the_listing_is_denied(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            gh = bin_dir / "gh"
+            gh.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")  # denied
+            gh.chmod(0o755)
+
+            result = subprocess.run(
+                [str(ROOT / "scripts" / "action" / "fetch-state.sh")],
+                env={
+                    "PATH": f"{bin_dir}:{os.environ['PATH']}",
+                    "RUNNER_TEMP": str(root),
+                    "REPOSITORY": "owner/repo",
+                    "GH_HOST": "https://github.com",
+                    "ARTIFACT_NAME": "codeboarding-base-cfg-sha",
+                    "DEST": str(root / "out"),
+                },
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("actions: read", result.stdout)
+            self.assertFalse((root / "out").exists())


### PR DESCRIPTION
Found while trying to run an end-to-end test on CodeBoarding-webview.

## The symptom

Every review run there prints:

```
##[notice]No stored codeboarding-base-50425f98…-4884c1f5… to reuse
##[notice]No stored codeboarding-warmstart-50425f98…-pr81 to reuse
```

and then, in the same run, publishes both bundles successfully. It looks like a repository that is permanently cold for no reason.

## The cause

Listing artifacts requires `actions: read`. **Uploading requires nothing.** The webview's review job grants `contents`, `pull-requests`, `issues` and `id-token`, so it can publish but never look. And because the listing call was `|| true`, a denial produced the same message as an empty result — the one an empty repository legitimately prints on its first run.

So a misconfigured repository pays for a full derivation on every run, publishes bundles nobody will ever read, and has no way to find out.

## The fix

A denied listing now warns and names the permission:

```
::warning::Could not list artifacts in owner/repo. Add 'actions: read' to the
job's permissions to reuse previous analyses; deriving from the base for now.
```

A genuinely empty result still prints the notice it always did. Behaviour is otherwise unchanged: reuse remains best-effort and the run derives from the base either way.

`test_it_says_why_when_the_listing_is_denied` covers it. 94 tests pass.

## Follow-up, not in this PR

CodeBoarding-webview needs `actions: read` added to its review job before any of the reuse works there, and the workflow template the webview generates for users needs the same line — otherwise every repository it onboards lands in this state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
