### PR TITLE
fix(action): pin CodeBoarding 0.13.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For a direct provider, pass its name and key:
 
 The action maps a provider name to the environment variable Core uses (`anthropic` → `ANTHROPIC_API_KEY`, `openai` → `OPENAI_API_KEY`, and so on). `aws`/`aws_bedrock` maps to `AWS_BEARER_TOKEN_BEDROCK`. Provider names following the standard convention are not restricted by an action-side allowlist; the pinned Core release remains the source of truth for which providers it implements.
 
-CodeBoarding 0.13.8 supports OpenRouter, OpenAI-compatible endpoints, Anthropic, Google, Vercel AI Gateway, AWS Bedrock, Cerebras, DeepSeek, GLM, Kimi, Ollama, and LiteLLM. See Core's [`agents/llm_config.py`](https://github.com/CodeBoarding/CodeBoarding/blob/main/agents/llm_config.py) for current defaults and endpoint variables. In particular, Ollama needs `OLLAMA_BASE_URL` or `OLLAMA_HOST`, and LiteLLM needs `LITELLM_BASE_URL` on the action step.
+CodeBoarding 0.13.10 supports OpenRouter, OpenAI-compatible endpoints, Anthropic-compatible endpoints, Google, Vercel AI Gateway, AWS Bedrock, Cerebras, DeepSeek, GLM, Kimi, OrcaRouter, Ollama, and LiteLLM. See Core's [`agents/llm_config.py`](https://github.com/CodeBoarding/CodeBoarding/blob/main/agents/llm_config.py) for current defaults and endpoint variables. In particular, Ollama needs `OLLAMA_BASE_URL` or `OLLAMA_HOST`, and LiteLLM needs `LITELLM_BASE_URL` on the action step.
 
 A CodeBoarding license keeps the hosted OIDC path but removes hosted quota limits:
 
@@ -237,7 +237,7 @@ With the default `github.token`, the repository or organization must allow GitHu
 | `force_full` | sync | `false` | Ignore the committed baseline for this run. |
 | `warmstart_retention_days` | review | `1` | Days to keep the reusable analysis. Only the next run reads it. |
 
-The `/codeboarding` command, comment heading, Mermaid direction (`LR`), hosted webview URL, rolling sync branch, commit message, and CodeBoarding 0.13.8 version are intentionally fixed in v2 rather than exposed as configuration.
+The `/codeboarding` command, comment heading, Mermaid direction (`LR`), hosted webview URL, rolling sync branch, commit message, and CodeBoarding 0.13.10 version are intentionally fixed in v2 rather than exposed as configuration.
 
 ## Outputs
 
@@ -271,7 +271,7 @@ Run the local analysis pipeline:
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-...
-python -m pip install codeboarding==0.13.8
+python -m pip install codeboarding==0.13.10
 tests/run_local.sh --repo /path/to/repo --base main --head feature
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -165,13 +165,8 @@ runs:
     - name: Install CodeBoarding
       if: steps.guard.outputs.skip != 'true'
       shell: bash
-      # tqdm is imported by the pinned CLI but missing from its dependencies. It
-      # used to arrive through openai, which dropped it in 3.3.0, so every fresh
-      # resolve since then installs a CLI that cannot start. Naming it here is a
-      # workaround for that packaging gap, not a dependency of this action;
-      # remove it once the engine declares its own.
       run: |
-        python -m pip install --disable-pip-version-check 'codeboarding==0.13.8' tqdm
+        python -m pip install --disable-pip-version-check 'codeboarding==0.13.10'
         # Fail here, with the reason, rather than mid-analysis with a traceback:
         # pinning a release does not pin what its dependencies resolve to. Run
         # the console script, not `python -c`, which would put the analyzed

--- a/scripts/action/install-sync.sh
+++ b/scripts/action/install-sync.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 output="$CHECKOUT_DIR/.codeboarding"
 mkdir -p "$output"
-# New Core releases expose one canonical manifest. The compatibility imports
-# keep the currently pinned 0.13.8 release usable without duplicating filenames.
+# Core exposes one canonical manifest. The compatibility imports keep the local
+# harness usable with older Core checkouts without duplicating filenames.
 manifest="$(cd "$ACTION_PATH" && python3 - <<'PY'
 try:
     from constants import ANALYSIS_FILENAME, PERSISTED_ANALYSIS_ARTIFACT_FILENAMES as artifacts


### PR DESCRIPTION
## What

- Pin the action runtime to the published `codeboarding==0.13.10` engine.
- Remove the action-side `tqdm` workaround because Core now declares that runtime dependency itself.
- Update the fixed-version and provider documentation for 0.13.10, including Anthropic-compatible endpoints and OrcaRouter.

## Release path

Merge this PR **before #99**. The `fix(action):` title is intentional: after squash merge, release-please will treat the engine update as release-worthy and refresh #99 to include it. Then merge the refreshed #99 to publish action 1.12.2 and move the major tag.

If #99 is merged first, it will ship only the fixes currently listed there and this engine pin will require the next patch release instead.

## Verification

- `python -m unittest discover -s tests -v` (94 passed, including the protected merge-base tests)
- `actionlint`
- Fresh Python 3.12 install of the published 0.13.10 wheel; `codeboarding --help` starts successfully