### PR TITLE
fix(action): restore Core runtime compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,34 @@ jobs:
       - name: Run unit tests (stdlib only)
         run: python -m unittest discover -s tests -v
 
+  core-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install pinned CodeBoarding release
+        shell: bash
+        run: |
+          set -euo pipefail
+          requirement="$(sed -n "s/.*'\(codeboarding==[^']*\)'.*/\1/p" action.yml)"
+          if [ -z "$requirement" ]; then
+            echo "Could not resolve the CodeBoarding requirement from action.yml" >&2
+            exit 1
+          fi
+          python -m pip install --disable-pip-version-check "$requirement"
+      - name: Render with the installed CodeBoarding release
+        run: >-
+          python scripts/diff_to_mermaid.py
+          --base .codeboarding/analysis.json
+          --head .codeboarding/analysis.json
+          --out "${RUNNER_TEMP}/diagram.md"
+          --direction LR
+          --render-depth 1
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/action.yml
+++ b/action.yml
@@ -162,6 +162,13 @@ runs:
       with:
         python-version: '3.12'
 
+    - name: Setup Java for CodeBoarding
+      if: steps.guard.outputs.skip != 'true'
+      uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: '21'
+
     - name: Install CodeBoarding
       if: steps.guard.outputs.skip != 'true'
       shell: bash

--- a/scripts/diff_to_mermaid.py
+++ b/scripts/diff_to_mermaid.py
@@ -87,8 +87,8 @@ def read_analysis_json(path: Path) -> dict:
 def load_analysis(path: Path) -> dict:
     data = read_analysis_json(path)
     try:
-        from codeboarding_workflows.rendering import project_relations_to_level
         from diagram_analysis.analysis_json import build_id_to_name_map, parse_unified_analysis
+        from output_generators.rendering import project_relations_to_level
     except ImportError as exc:
         sys.exit(f"::error::Could not load the installed CodeBoarding analysis reader: {exc}")
 

--- a/tests/test_action_sync.py
+++ b/tests/test_action_sync.py
@@ -292,9 +292,9 @@ class ActionSyncTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             fake_core = root / "core"
-            (fake_core / "codeboarding_workflows").mkdir(parents=True)
-            (fake_core / "diagram_analysis").mkdir()
-            (fake_core / "codeboarding_workflows" / "rendering.py").write_text(
+            (fake_core / "diagram_analysis").mkdir(parents=True)
+            (fake_core / "output_generators").mkdir(parents=True)
+            (fake_core / "output_generators" / "rendering.py").write_text(
                 "def project_relations_to_level(*args): return []\n", encoding="utf-8"
             )
             (fake_core / "diagram_analysis" / "analysis_json.py").write_text(

--- a/tests/test_diff_to_mermaid.py
+++ b/tests/test_diff_to_mermaid.py
@@ -76,16 +76,16 @@ class TestDiff(unittest.TestCase):
                 )
             return projected
 
-        rendering = ModuleType("codeboarding_workflows.rendering")
+        rendering = ModuleType("output_generators.rendering")
         rendering.project_relations_to_level = project_relations_to_level
         analysis_json = ModuleType("diagram_analysis.analysis_json")
         analysis_json.parse_unified_analysis = parse_unified_analysis
         analysis_json.build_id_to_name_map = build_id_to_name_map
         modules = {
-            "codeboarding_workflows": ModuleType("codeboarding_workflows"),
-            "codeboarding_workflows.rendering": rendering,
             "diagram_analysis": ModuleType("diagram_analysis"),
             "diagram_analysis.analysis_json": analysis_json,
+            "output_generators": ModuleType("output_generators"),
+            "output_generators.rendering": rendering,
         }
         analysis = {
             "components": [


### PR DESCRIPTION
## Summary
- select Temurin 21 inside the composite action so JDTLS can analyze Java repositories
- import relation projection from its packaged CodeBoarding 0.13.10 module
- align renderer mocks with the installed package layout
- smoke-test the pinned Core release by rendering the checked-in analysis in CI

## Verification
- `python3 -m unittest discover -s tests -v` — 94 passed
- `pre-commit run --all-files` — Black passed
- Spring PetClinic run confirmed Java 21 starts JDTLS; the stale renderer import was the remaining failure

This is a `fix:` change so release-please will propose a patch release.