### PR TITLE
fix: bump CodeBoarding engine to 0.13.11

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -353,7 +353,7 @@ runs:
       if: steps.guard.outputs.skip != 'true'
       shell: bash
       run: |
-        python -m pip install --disable-pip-version-check 'codeboarding==0.13.10'
+        python -m pip install --disable-pip-version-check 'codeboarding==0.13.11'
         # Fail here, with the reason, rather than mid-analysis with a traceback:
         # pinning a release does not pin what its dependencies resolve to. Run
         # the console script, not `python -c`, which would put the analyzed

--- a/scripts/action/supported-providers.json
+++ b/scripts/action/supported-providers.json
@@ -18,7 +18,7 @@
     "a selection env (AWS_DEFAULT_REGION, OLLAMA_API_KEY) therefore cannot select a provider",
     "on its own, which is why ollama and litellm need their base URL and not just a key."
   ],
-  "engine": "0.13.10",
+  "engine": "0.13.11",
   "hosted_provider": "openrouter",
   "providers": {
     "openrouter": {


### PR DESCRIPTION
## Summary
- pin the CodeBoarding engine to 0.13.11
- keep the pre-install provider contract metadata aligned with the pinned engine

## Validation
- `python -m unittest tests.test_action_inputs tests.test_provider_table_drift` (18 passed/skipped as designed when the pinned distribution is unavailable)
- `git diff --check`
- verified the provider selection/API-key contract is unchanged from 0.13.10 to the merged 0.13.11 core source

## Merge note
CodeBoarding 0.13.11 is merged in core but must be published to PyPI before this action pin can install successfully.