### PR TITLE
feat: update CodeBoarding dependency to 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ With the default `github.token`, the repository or organization must allow GitHu
 | `force_full` | sync | `false` | Ignore the committed baseline for this run. |
 | `warmstart_retention_days` | review | `1` | Days to keep the reusable analysis. Only the next run reads it. |
 
-The `/codeboarding` command, comment heading, Mermaid direction (`LR`), hosted webview URL, rolling sync branch, commit message, and CodeBoarding 0.13.10 version are intentionally fixed rather than exposed as configuration.
+The `/codeboarding` command, comment heading, Mermaid direction (`LR`), hosted webview URL, rolling sync branch, commit message, and CodeBoarding 0.14.0 version are intentionally fixed rather than exposed as configuration.
 
 ## Outputs
 
@@ -347,7 +347,7 @@ Run the local analysis pipeline:
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-...
-python -m pip install codeboarding==0.13.10
+python -m pip install codeboarding==0.14.0
 tests/run_local.sh --repo /path/to/repo --base main --head feature
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -353,7 +353,7 @@ runs:
       if: steps.guard.outputs.skip != 'true'
       shell: bash
       run: |
-        python -m pip install --disable-pip-version-check 'codeboarding==0.13.11'
+        python -m pip install --disable-pip-version-check 'codeboarding==0.14.0'
         # Fail here, with the reason, rather than mid-analysis with a traceback:
         # pinning a release does not pin what its dependencies resolve to. Run
         # the console script, not `python -c`, which would put the analyzed

--- a/scripts/action/supported-providers.json
+++ b/scripts/action/supported-providers.json
@@ -18,7 +18,7 @@
     "a selection env (AWS_DEFAULT_REGION, OLLAMA_API_KEY) therefore cannot select a provider",
     "on its own, which is why ollama and litellm need their base URL and not just a key."
   ],
-  "engine": "0.13.11",
+  "engine": "0.14.0",
   "hosted_provider": "openrouter",
   "providers": {
     "openrouter": {


### PR DESCRIPTION
Re-pin the analysis engine to codeboarding `0.14.0` at its four sites: the install literal in `action.yml`, the `engine` field of `scripts/action/supported-providers.json`, and the two README references (which had drifted to 0.13.10). Core 0.14.0 is published on PyPI, and the install, compatibility, provider-drift, unit, lint, and end-to-end review checks passed against that published artifact. The action's provider table is unchanged: it matches 0.14.0's `LLM_PROVIDERS`.

**Release intent:** this Core upgrade ships as the minor CodeBoarding-action release v1.14.0. Because this PR was merged before its commit type could be corrected, release PR #119 was regenerated explicitly as v1.14.0 with release-please.

BEGIN_COMMIT_OVERRIDE
feat(engine): generate deeper architecture-aligned component hierarchies

perf(engine): reduce analysis time and model-token usage

fix(engine): ground relationships and assign each method to one component

fix(engine): prevent raw fallback names, checkout-path leakage, duplicate names, and empty components

fix(engine): preserve Java and C# package, type, and constructor structure

fix(engine): keep incremental structure correct for new and deleted components

fix(action): rebuild 0.13.x baselines once before incremental analysis resumes
END_COMMIT_OVERRIDE
