### PR TITLE
fix: update CodeBoarding dependency to 0.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ With the default `github.token`, the repository or organization must allow GitHu
 | `force_full` | sync | `false` | Ignore the committed baseline for this run. |
 | `warmstart_retention_days` | review | `1` | Days to keep the reusable analysis. Only the next run reads it. |
 
-The `/codeboarding` command, comment heading, Mermaid direction (`LR`), hosted webview URL, rolling sync branch, commit message, and CodeBoarding 0.14.1 version are intentionally fixed rather than exposed as configuration.
+The `/codeboarding` command, comment heading, Mermaid direction (`LR`), hosted webview URL, rolling sync branch, commit message, and CodeBoarding 0.14.2 version are intentionally fixed rather than exposed as configuration.
 
 Review mode needs no sync workflow or committed `.codeboarding` directory. If no
 usable merge-base analysis exists, it runs full analysis there directly, then
@@ -331,7 +331,7 @@ early. The action input matches the metadata name and the engine receives only
 `--depth-cap`. There are no old-name input aliases. Historical workflows using
 the removed `depth_level` action input must switch to `depth_cap`.
 
-This action pins Core 0.14.1 for the `--depth-cap` CLI contract. Publish that Core
+This action pins Core 0.14.2 for the `--depth-cap` CLI contract. Publish that Core
 release before releasing the action. Earlier eShop evidence predates this final
 breaking CLI migration.
 
@@ -370,7 +370,7 @@ Run the local analysis pipeline:
 
 ```bash
 export OPENROUTER_API_KEY=sk-or-...
-python -m pip install codeboarding==0.14.1
+python -m pip install codeboarding==0.14.2
 tests/run_local.sh --repo /path/to/repo --base main --head feature
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -357,7 +357,7 @@ runs:
       if: steps.guard.outputs.skip != 'true'
       shell: bash
       run: |
-        python -m pip install --disable-pip-version-check 'codeboarding==0.14.1'
+        python -m pip install --disable-pip-version-check 'codeboarding==0.14.2'
         # Fail here, with the reason, rather than mid-analysis with a traceback:
         # pinning a release does not pin what its dependencies resolve to. Run
         # the console script, not `python -c`, which would put the analyzed

--- a/scripts/action/supported-providers.json
+++ b/scripts/action/supported-providers.json
@@ -18,7 +18,7 @@
     "a selection env (AWS_DEFAULT_REGION, OLLAMA_API_KEY) therefore cannot select a provider",
     "on its own, which is why ollama and litellm need their base URL and not just a key."
   ],
-  "engine": "0.14.1",
+  "engine": "0.14.2",
   "hosted_provider": "openrouter",
   "providers": {
     "openrouter": {


### PR DESCRIPTION
Re-pin the analysis engine to codeboarding `0.14.2`. **Do not merge until `0.14.2` is published to PyPI** — the install step runs `pip install codeboarding==0.14.2`.

Also fixes existing pin drift: `action.yml` and `supported-providers.json` were on `0.13.11` while the README still said `0.13.10`. All four sites now agree.